### PR TITLE
feat: add npm binary distribution, unit tests, and agent guides

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,13 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [[ "$GITHUB_REF_NAME" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "VERSION=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Error: tag '$GITHUB_REF_NAME' does not match expected pattern 'v<major>.<minor>.<patch>'" >&2
+            exit 1
+          fi
 
       - name: Publish platform packages
         env:
@@ -139,10 +145,11 @@ jobs:
 
             cp "artifacts/${artifact_name}/${bin_name}" "npm/${npm_dir}/${bin_name}"
             chmod +x "npm/${npm_dir}/${bin_name}" 2>/dev/null || true
-            cd "npm/${npm_dir}"
-            npm version "${VERSION}" --no-git-tag-version
-            npm publish --access public
-            cd ../..
+            (
+              cd "npm/${npm_dir}" &&
+              npm version "${VERSION}" --no-git-tag-version &&
+              npm publish --access public
+            )
           }
 
           publish_platform "inboxapi-cli-linux-x64"   "cli-linux-x64"   "inboxapi-cli"
@@ -158,13 +165,40 @@ jobs:
           VERSION="${{ steps.version.outputs.VERSION }}"
 
           # Stamp version on root package and align optionalDependencies
-          node -e "
-            const pkg = require('./package.json');
-            pkg.version = '${VERSION}';
-            for (const dep of Object.keys(pkg.optionalDependencies || {})) {
-              pkg.optionalDependencies[dep] = '${VERSION}';
-            }
-            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
+          OPTIONAL_DEPS="$(
+            node -e "
+              const fs = require('fs');
+              const pkg = require('./package.json');
+              pkg.version = '${VERSION}';
+              const deps = Object.keys(pkg.optionalDependencies || {});
+              for (const dep of deps) {
+                pkg.optionalDependencies[dep] = '${VERSION}';
+              }
+              fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+              console.log(deps.join(' '));
+            "
+          )"
+
+          # Wait for platform packages to be visible on npm before publishing main package
+          if [ -n "$OPTIONAL_DEPS" ]; then
+            for dep in $OPTIONAL_DEPS; do
+              echo "Verifying availability of ${dep}@${VERSION} on npm..."
+              attempt=1
+              max_attempts=5
+              while true; do
+                if npm view "${dep}@${VERSION}" version --json >/dev/null 2>&1; then
+                  echo "Found ${dep}@${VERSION} on npm."
+                  break
+                fi
+                if [ "$attempt" -ge "$max_attempts" ]; then
+                  echo "ERROR: ${dep}@${VERSION} not visible on npm after ${max_attempts} attempts." >&2
+                  exit 1
+                fi
+                echo "  ${dep}@${VERSION} not yet visible (attempt ${attempt}/${max_attempts}), retrying in 10s..."
+                attempt=$((attempt + 1))
+                sleep 10
+              done
+            done
+          fi
 
           npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,22 +16,27 @@ jobs:
             os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             name: inboxapi-cli-linux-x64
+            npm-dir: cli-linux-x64
           - os-name: Linux-aarch64
             os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             name: inboxapi-cli-linux-arm64
+            npm-dir: cli-linux-arm64
           - os-name: macOS-x86_64
             os: macos-latest
             target: x86_64-apple-darwin
             name: inboxapi-cli-macos-x64
+            npm-dir: cli-darwin-x64
           - os-name: macOS-aarch64
             os: macos-latest
             target: aarch64-apple-darwin
             name: inboxapi-cli-macos-arm64
+            npm-dir: cli-darwin-arm64
           - os-name: Windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
             name: inboxapi-cli-windows-x64
+            npm-dir: cli-win32-x64
 
     steps:
       - uses: actions/checkout@v4
@@ -67,7 +72,7 @@ jobs:
         with:
           name: ${{ matrix.platform.name }}
           path: dist/*
-          
+
   release:
     name: GitHub Release
     runs-on: ubuntu-latest
@@ -79,7 +84,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-          
+
       - name: Prepare Release Assets
         run: |
           mkdir -p release-assets
@@ -93,9 +98,73 @@ jobs:
               fi
             fi
           done
-          
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: release-assets/*
           fail_on_unmatched_files: true
+
+  npm-publish:
+    name: Publish npm packages
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish platform packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+
+          publish_platform() {
+            local artifact_name="$1"
+            local npm_dir="$2"
+            local bin_name="$3"
+
+            cp "artifacts/${artifact_name}/${bin_name}" "npm/${npm_dir}/${bin_name}"
+            chmod +x "npm/${npm_dir}/${bin_name}" 2>/dev/null || true
+            cd "npm/${npm_dir}"
+            npm version "${VERSION}" --no-git-tag-version
+            npm publish --access public
+            cd ../..
+          }
+
+          publish_platform "inboxapi-cli-linux-x64"   "cli-linux-x64"   "inboxapi-cli"
+          publish_platform "inboxapi-cli-linux-arm64"  "cli-linux-arm64" "inboxapi-cli"
+          publish_platform "inboxapi-cli-macos-x64"    "cli-darwin-x64"  "inboxapi-cli"
+          publish_platform "inboxapi-cli-macos-arm64"  "cli-darwin-arm64" "inboxapi-cli"
+          publish_platform "inboxapi-cli-windows-x64"  "cli-win32-x64"  "inboxapi-cli.exe"
+
+      - name: Publish main package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+
+          # Stamp version on root package and align optionalDependencies
+          node -e "
+            const pkg = require('./package.json');
+            pkg.version = '${VERSION}';
+            for (const dep of Object.keys(pkg.optionalDependencies || {})) {
+              pkg.optionalDependencies[dep] = '${VERSION}';
+            }
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+          npm publish --access public

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /target
+node_modules/
+npm/cli-*/inboxapi-cli
+npm/cli-*/inboxapi-cli.exe
+dist/
+*.tgz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# InboxAPI CLI — Agent Guide
+
+## Overview
+Rust STDIO proxy bridging JSON-RPC (MCP protocol) to the remote InboxAPI MCP service over Streamable HTTP/SSE. Installed via `npm install -g @inboxapi/cli`.
+
+## Quickstart
+```bash
+cargo build          # Build the binary
+cargo test           # Run tests
+cargo fmt            # Format Rust code
+cargo run -- proxy   # Start proxy (default subcommand)
+cargo run -- login   # Authenticate
+```
+
+## Architecture
+
+### Proxy Loop (`src/main.rs`)
+1. Connects to remote SSE endpoint
+2. Spawns a task that forwards SSE `message` events to stdout
+3. Reads JSON-RPC lines from stdin, injects stored access token into `tools/call` arguments, POSTs to remote endpoint
+
+### Token Injection
+The `inject_token` function adds the stored `token` field to `tools/call` arguments, skipping public tools (`help`, `account_create`, `auth_exchange`, `auth_refresh`).
+
+### Login Flow
+1. Generates SHA-1 hashcash proof-of-work for the account name
+2. Calls `account_create` to get a bootstrap token
+3. Calls `auth_exchange` to swap for access + refresh tokens
+4. Saves credentials to OS config directory (`~/.config/inboxapi/credentials.json` on Linux)
+
+### npm Distribution
+The `index.js` wrapper resolves the correct platform binary from optional npm dependencies (`@inboxapi/cli-<os>-<arch>`), falling back to local builds or `cargo run` for development.
+
+## Repo Structure
+```
+src/main.rs                    — All proxy, auth, and CLI logic
+index.js                       — npm binary resolver
+package.json                   — Root npm package
+npm/cli-darwin-arm64/          — macOS ARM64 platform package
+npm/cli-darwin-x64/            — macOS x64 platform package
+npm/cli-linux-x64/             — Linux x64 platform package
+npm/cli-linux-arm64/           — Linux ARM64 platform package
+npm/cli-win32-x64/             — Windows x64 platform package
+.github/workflows/release.yml  — CI: build, release, npm publish
+Cargo.toml                     — Rust dependencies
+```
+
+## Rules
+- Read relevant code before making changes
+- Make surgical, focused edits — avoid unnecessary refactoring
+- Run `cargo fmt` before committing Rust changes
+- Use conventional commits (`feat:`, `fix:`, `chore:`, etc.)
+- Do not add AI attribution to commits, code, or comments
+- Keep `src/main.rs` as a single file — this is a simple proxy, not a framework
+
+## Contribution Workflow
+1. Create a feature branch from `main`
+2. Implement changes with focused commits
+3. Run `cargo build && cargo test && cargo fmt --check`
+4. Open a PR against `main`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,31 +1,39 @@
-# InboxAPI CLI - Claude/AI Agent Context
+# InboxAPI CLI
 
-## Project Overview
-A Rust-based STDIO proxy for the InboxAPI MCP service. It allows AI tools (like Claude Desktop/Code) that speak JSON-RPC over STDIO to communicate with the remote InboxAPI MCP service hosted over SSE/HTTP.
+## Overview
+Rust-based STDIO proxy that bridges JSON-RPC (MCP protocol) over STDIO to the remote InboxAPI MCP service over Streamable HTTP/SSE. Distributed via npm as `@inboxapi/cli`.
 
-## Development Commands
-- `cargo build`: Build the project
-- `cargo run -- login`: Log in to the service
-- `cargo run -- proxy`: Start the STDIO proxy (default)
+## Commands
+- `cargo build` — build the Rust binary
+- `cargo test` — run tests
+- `cargo run -- proxy` — start the STDIO proxy (default)
+- `cargo run -- login` — authenticate and store credentials
+- `cargo run -- whoami` — show current account info
 
 ## Architecture
-- **Transport**: Bridges STDIO (stdin/stdout) to remote SSE (Server-Sent Events) and POST requests.
-- **Authentication**: Automatically injects access tokens from the OS config directory (e.g., `~/.config/inboxapi/credentials.json` on Linux) into tool calls.
-- **Onboarding**: Includes a `login` command that handles Hashcash proof-of-work and token exchange.
+- **Single-file proxy** (`src/main.rs`): reads JSON-RPC from stdin, POSTs to remote endpoint, streams SSE responses to stdout. Injects stored access tokens into `tools/call` arguments.
+- **npm wrapper** (`index.js`): resolves the platform-specific binary from `@inboxapi/cli-<os>-<arch>` optional dependencies, falls back to local `target/` builds or `cargo run`.
+- **CI** (`.github/workflows/release.yml`): builds 5 platform binaries on tag push, creates GitHub Release, publishes platform + root npm packages.
+
+## npm Distribution
+```
+@inboxapi/cli              — root package (index.js wrapper + optionalDependencies)
+@inboxapi/cli-darwin-arm64 — macOS ARM64 binary
+@inboxapi/cli-darwin-x64   — macOS x64 binary
+@inboxapi/cli-linux-x64    — Linux x64 binary
+@inboxapi/cli-linux-arm64  — Linux ARM64 binary
+@inboxapi/cli-win32-x64    — Windows x64 binary
+```
 
 ## Key Files
-- `src/main.rs`: Core proxy and login logic.
-- `Cargo.toml`: Project dependencies.
+- `src/main.rs` — proxy logic, token injection, login flow, hashcash PoW
+- `index.js` — npm binary resolver (platform package → local build → cargo run)
+- `package.json` — root npm package with optionalDependencies
+- `npm/cli-*/package.json` — platform-specific npm package manifests
+- `.github/workflows/release.yml` — cross-build + GitHub Release + npm publish
+- `Cargo.toml` — Rust dependencies
 
-## Usage for AI Tools
-To use this with Claude Desktop, add to `claude_desktop_config.json`:
-```json
-{
-  "mcpServers": {
-    "inboxapi": {
-      "command": "path/to/inboxapi-cli",
-      "args": ["proxy"]
-    }
-  }
-}
-```
+## Rules
+- Do not add AI attribution to commits, code, or comments
+- Run `cargo fmt` before committing Rust changes
+- Use conventional commits (`feat:`, `fix:`, `chore:`, etc.)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,40 +1,51 @@
-# InboxAPI CLI - Gemini Agent Context
+# InboxAPI CLI — Gemini Agent Context
 
-## Repository Overview
-InboxAPI CLI is a Rust-based STDIO proxy for the InboxAPI MCP service. It provides a simple, cross-platform bridge for AI tools to access email capabilities through a remote MCP endpoint.
+## Overview
+Rust STDIO proxy that bridges JSON-RPC (MCP protocol) over STDIO to the remote InboxAPI MCP service over Streamable HTTP/SSE. Distributed as `@inboxapi/cli` on npm with platform-specific binary packages.
 
 ## Technology Stack
-- **Language:** Rust (Tokio, reqwest, eventsource-client)
-- **Protocol:** JSON-RPC (MCP standard over STDIO)
-- **Transport:** HTTP/SSE (to remote service)
-- **Packaging:** Planned as npm package (`@inboxapi/cli`)
+- **Language:** Rust (Tokio async runtime, reqwest HTTP client, eventsource-client SSE)
+- **Protocol:** JSON-RPC over STDIO (MCP standard)
+- **Transport:** HTTP POST + SSE to remote endpoint
+- **Distribution:** npm with platform-specific optional dependencies
+- **CI:** GitHub Actions (5-platform cross-build, GitHub Releases, npm publish)
 
-## Environment & Setup
-- **Credentials:** Stored under the OS config directory (e.g. `~/.config/inboxapi/credentials.json` on Linux).
-- **Remote Endpoint:** Default is `https://mcp.inboxapi.ai/mcp`.
-
-## Development Commands
+## Commands
 ```bash
-cargo check     # Type check
-cargo build     # Build binary
-cargo run -- login # Authentication flow
-cargo run -- proxy # Start proxy (default)
+cargo build          # Build binary
+cargo test           # Run tests
+cargo fmt            # Format code
+cargo run -- proxy   # Start STDIO proxy (default)
+cargo run -- login   # Authenticate and store credentials
+cargo run -- whoami  # Show current account
 ```
 
-## Implementation Notes
-- **Authentication:** Injects the access token value as the `token` field in the `arguments` of `tools/call` JSON-RPC messages when the method is `tools/call` and the `token` argument is missing.
-- **Hashcash:** Custom SHA-1 implementation in `src/main.rs` for `account_create`.
-- **Proxy Loop:**
-  - `stdin` -> `POST` to remote.
-  - `SSE` from remote -> `stdout`.
+## Development Workflow
+- Single Rust source file (`src/main.rs`) containing all proxy, auth, and CLI logic
+- `index.js` is the npm entry point — resolves platform binary or falls back to `cargo run`
+- Tags (`v*.*.*`) trigger CI builds and npm publishing
 
-## Release Strategy
-For npm distribution, we recommend a main package `@inboxapi/cli` that uses platform-specific optional dependencies containing the pre-compiled Rust binaries. This is the standard approach used by tools like `esbuild` and `swc`.
+## Key Files
+- `src/main.rs` — Proxy loop, token injection, login flow, hashcash proof-of-work
+- `index.js` — npm binary resolver (platform package → local build → cargo run)
+- `package.json` — Root npm package with `optionalDependencies` for 5 platforms
+- `npm/cli-*/package.json` — Platform-specific package manifests (os/cpu fields)
+- `.github/workflows/release.yml` — Cross-build, GitHub Release, npm publish pipeline
+- `Cargo.toml` — Rust project configuration and dependencies
 
-## Synchronizing with `inboxapi-mcp`
-Since this CLI is a pure proxy, it only needs to be updated if:
-1. The transport protocol (SSE/Streamable HTTP) changes.
-2. The authentication method (token injection logic) changes.
-3. The remote endpoint address changes.
+## npm Distribution
+```
+@inboxapi/cli              — Main package (wrapper script)
+@inboxapi/cli-darwin-arm64 — macOS ARM64
+@inboxapi/cli-darwin-x64   — macOS x64
+@inboxapi/cli-linux-x64    — Linux x64
+@inboxapi/cli-linux-arm64  — Linux ARM64
+@inboxapi/cli-win32-x64    — Windows x64
+```
 
-The specific tools and resources are handled opaquely by the proxy, so changes to individual tools in `inboxapi-mcp` do not require updates to this CLI.
+Users install with `npm install -g @inboxapi/cli`. npm automatically selects the correct platform binary via the `os` and `cpu` fields in each platform package.
+
+## Rules
+- Do not add AI attribution to commits, code, or comments
+- Run `cargo fmt` before committing Rust changes
+- Use conventional commits (`feat:`, `fix:`, `chore:`, etc.)

--- a/index.js
+++ b/index.js
@@ -60,7 +60,11 @@ if (binPath) {
     process.exit(1);
   });
   child.on('error', () => {
-    console.error("Binary not found and 'cargo' failed to start. Have you built the project?");
+    const platformKey = `${process.platform}-${process.arch}`;
+    console.error(
+      `No pre-built binary available for ${platformKey}. Supported platforms: ${Object.keys(PLATFORM_PACKAGES).join(', ')}.\n` +
+      `Fallback to 'cargo run' also failed. Install Rust (https://rustup.rs) or use a supported platform.`
+    );
     process.exit(1);
   });
 }

--- a/index.js
+++ b/index.js
@@ -4,31 +4,43 @@ const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
-/**
- * InboxAPI CLI Wrapper
- * 
- * In a real production package, this script would:
- * 1. Detect the platform (OS/Arch)
- * 2. Find the pre-compiled binary packaged with the npm module
- * 3. Or download it if not present
- * 
- * For development, it checks target/release or target/debug, 
- * or falls back to 'cargo run --quiet -- ...'.
- */
+const PLATFORM_PACKAGES = {
+  'darwin-arm64': '@inboxapi/cli-darwin-arm64',
+  'darwin-x64': '@inboxapi/cli-darwin-x64',
+  'linux-x64': '@inboxapi/cli-linux-x64',
+  'linux-arm64': '@inboxapi/cli-linux-arm64',
+  'win32-x64': '@inboxapi/cli-win32-x64',
+};
 
 const binName = process.platform === 'win32' ? 'inboxapi-cli.exe' : 'inboxapi-cli';
-const searchPaths = [
-  path.join(__dirname, binName),
-  path.join(__dirname, 'target', 'release', binName),
-  path.join(__dirname, 'target', 'debug', binName),
-];
 
-let binPath = searchPaths.find(p => fs.existsSync(p));
+function findBinary() {
+  // 1. Try platform-specific npm package (production install)
+  const platformKey = `${process.platform}-${process.arch}`;
+  const pkg = PLATFORM_PACKAGES[platformKey];
+  if (pkg) {
+    try {
+      const pkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
+      const binPath = path.join(pkgDir, binName);
+      if (fs.existsSync(binPath)) return binPath;
+    } catch {}
+  }
 
+  // 2. Fall back to local dev paths
+  const devPaths = [
+    path.join(__dirname, 'target', 'release', binName),
+    path.join(__dirname, 'target', 'debug', binName),
+  ];
+  const found = devPaths.find(p => fs.existsSync(p));
+  if (found) return found;
+
+  return null;
+}
+
+const binPath = findBinary();
 const args = process.argv.slice(2);
 
 if (binPath) {
-  // Run the native binary
   const child = spawn(binPath, args, { stdio: 'inherit' });
   child.on('exit', (code, signal) => {
     if (code !== null) process.exit(code);
@@ -40,15 +52,14 @@ if (binPath) {
     process.exit(1);
   });
 } else {
-  // Fallback to cargo run for development
-  // Note: this assumes 'cargo' is in the PATH
+  // 3. Final fallback: cargo run (development)
   const child = spawn('cargo', ['run', '--quiet', '--', ...args], { stdio: 'inherit' });
   child.on('exit', (code, signal) => {
     if (code !== null) process.exit(code);
     if (signal) process.kill(process.pid, signal);
     process.exit(1);
   });
-  child.on('error', (err) => {
+  child.on('error', () => {
     console.error("Binary not found and 'cargo' failed to start. Have you built the project?");
     process.exit(1);
   });

--- a/npm/cli-darwin-arm64/package.json
+++ b/npm/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-darwin-arm64",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "InboxAPI CLI binary for macOS ARM64",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/npm/cli-darwin-arm64/package.json
+++ b/npm/cli-darwin-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@inboxapi/cli-darwin-arm64",
+  "version": "0.0.0",
+  "description": "InboxAPI CLI binary for macOS ARM64",
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "main": "inboxapi-cli",
+  "files": ["inboxapi-cli"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shaond/inboxapi-cli.git"
+  },
+  "preferUnplugged": true
+}

--- a/npm/cli-darwin-x64/package.json
+++ b/npm/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-darwin-x64",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "InboxAPI CLI binary for macOS x64",
   "os": ["darwin"],
   "cpu": ["x64"],

--- a/npm/cli-darwin-x64/package.json
+++ b/npm/cli-darwin-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@inboxapi/cli-darwin-x64",
+  "version": "0.0.0",
+  "description": "InboxAPI CLI binary for macOS x64",
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "main": "inboxapi-cli",
+  "files": ["inboxapi-cli"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shaond/inboxapi-cli.git"
+  },
+  "preferUnplugged": true
+}

--- a/npm/cli-linux-arm64/package.json
+++ b/npm/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-linux-arm64",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "InboxAPI CLI binary for Linux ARM64",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/npm/cli-linux-arm64/package.json
+++ b/npm/cli-linux-arm64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@inboxapi/cli-linux-arm64",
+  "version": "0.0.0",
+  "description": "InboxAPI CLI binary for Linux ARM64",
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "main": "inboxapi-cli",
+  "files": ["inboxapi-cli"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shaond/inboxapi-cli.git"
+  },
+  "preferUnplugged": true
+}

--- a/npm/cli-linux-x64/package.json
+++ b/npm/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-linux-x64",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "InboxAPI CLI binary for Linux x64",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/npm/cli-linux-x64/package.json
+++ b/npm/cli-linux-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@inboxapi/cli-linux-x64",
+  "version": "0.0.0",
+  "description": "InboxAPI CLI binary for Linux x64",
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "main": "inboxapi-cli",
+  "files": ["inboxapi-cli"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shaond/inboxapi-cli.git"
+  },
+  "preferUnplugged": true
+}

--- a/npm/cli-win32-x64/package.json
+++ b/npm/cli-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-win32-x64",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "InboxAPI CLI binary for Windows x64",
   "os": ["win32"],
   "cpu": ["x64"],

--- a/npm/cli-win32-x64/package.json
+++ b/npm/cli-win32-x64/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@inboxapi/cli-win32-x64",
+  "version": "0.0.0",
+  "description": "InboxAPI CLI binary for Windows x64",
+  "os": ["win32"],
+  "cpu": ["x64"],
+  "main": "inboxapi-cli.exe",
+  "files": ["inboxapi-cli.exe"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shaond/inboxapi-cli.git"
+  },
+  "preferUnplugged": true
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bin": {
     "inboxapi": "index.js"
   },
+  "files": ["index.js"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/shaond/inboxapi-cli.git"
@@ -19,9 +20,15 @@
   ],
   "author": "Shaon Diwakar",
   "license": "MIT",
-  "dependencies": {},
   "scripts": {
     "build": "cargo build --release",
     "test": "cargo test"
+  },
+  "optionalDependencies": {
+    "@inboxapi/cli-darwin-arm64": "0.1.0",
+    "@inboxapi/cli-darwin-x64": "0.1.0",
+    "@inboxapi/cli-linux-x64": "0.1.0",
+    "@inboxapi/cli-linux-arm64": "0.1.0",
+    "@inboxapi/cli-win32-x64": "0.1.0"
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -543,6 +543,23 @@ mod tests {
         assert_eq!(msg, original);
     }
 
+    #[test]
+    fn inject_token_handles_null_name() {
+        let mut msg = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": null,
+                "arguments": {"foo": "bar"}
+            }
+        });
+        let original = msg.clone();
+        inject_token(&mut msg, "test-token");
+
+        assert_eq!(msg, original);
+    }
+
     // --- Credentials tests ---
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,16 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand};
 use eventsource_client::{Client, SSE};
 use futures_util::StreamExt;
-use reqwest::{Client as HttpClient, header::{CONTENT_TYPE, ACCEPT}};
+use reqwest::{
+    header::{ACCEPT, CONTENT_TYPE},
+    Client as HttpClient,
+};
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
-use std::path::PathBuf;
+use serde_json::{json, Value};
 use std::io::Write;
-use tokio::io::{AsyncBufReadExt, BufReader, stdin, stdout, AsyncWriteExt};
+use std::path::PathBuf;
+use tokio::io::{stdin, stdout, AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 #[derive(Parser)]
 #[command(name = "inboxapi")]
@@ -47,14 +50,15 @@ struct Credentials {
 }
 
 fn get_credentials_path() -> Result<PathBuf> {
-    let base_dir = dirs::config_dir()
-        .ok_or_else(|| anyhow!("Could not determine configuration directory"))?;
+    let base_dir =
+        dirs::config_dir().ok_or_else(|| anyhow!("Could not determine configuration directory"))?;
     Ok(base_dir.join("inboxapi").join("credentials.json"))
 }
 
 fn load_credentials() -> Result<Credentials> {
     let path = get_credentials_path()?;
-    let content = std::fs::read_to_string(path).context("Could not read credentials file. Have you run 'inboxapi login'?")?;
+    let content = std::fs::read_to_string(path)
+        .context("Could not read credentials file. Have you run 'inboxapi login'?")?;
     serde_json::from_str(&content).context("Failed to parse credentials file")
 }
 
@@ -164,7 +168,8 @@ async fn run_proxy(endpoint: String) -> Result<()> {
         }
 
         // Post to endpoint
-        let res = http_client.post(&endpoint)
+        let res = http_client
+            .post(&endpoint)
             .header(CONTENT_TYPE, "application/json")
             .header(ACCEPT, "application/json, text/event-stream")
             .json(&msg)
@@ -175,7 +180,10 @@ async fn run_proxy(endpoint: String) -> Result<()> {
             Ok(resp) => {
                 let status = resp.status();
                 if !status.is_success() {
-                    let err_text = resp.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+                    let err_text = resp
+                        .text()
+                        .await
+                        .unwrap_or_else(|_| "Unknown error".to_string());
                     eprintln!("POST failed ({}): {}", status, err_text);
                 }
             }
@@ -195,11 +203,17 @@ fn inject_token(msg: &mut Value, token: &str) {
             if let Some(params) = msg.get_mut("params").and_then(|p| p.as_object_mut()) {
                 if let Some(name) = params.get("name").and_then(|n| n.as_str()) {
                     // Skip public/auth tools that don't need or use different tokens
-                    if name == "help" || name == "account_create" || name == "auth_exchange" || name == "auth_refresh" {
+                    if name == "help"
+                        || name == "account_create"
+                        || name == "auth_exchange"
+                        || name == "auth_refresh"
+                    {
                         return;
                     }
 
-                    if let Some(arguments) = params.get_mut("arguments").and_then(|a| a.as_object_mut()) {
+                    if let Some(arguments) =
+                        params.get_mut("arguments").and_then(|a| a.as_object_mut())
+                    {
                         // Only inject if token is not already present
                         if !arguments.contains_key("token") {
                             arguments.insert("token".to_string(), json!(token));
@@ -230,7 +244,8 @@ async fn login_flow(name: Option<String>, endpoint: String) -> Result<()> {
 
     // 1. account_create
     println!("Creating account...");
-    let resp = http_client.post(&endpoint)
+    let resp = http_client
+        .post(&endpoint)
         .header(CONTENT_TYPE, "application/json")
         .json(&json!({
             "jsonrpc": "2.0",
@@ -250,17 +265,24 @@ async fn login_flow(name: Option<String>, endpoint: String) -> Result<()> {
         .await?;
 
     // Parse the response from tools/call
-    let content = resp.get("result").and_then(|r| r.get("content")).and_then(|c| c.as_array())
-        .and_then(|c| c.get(0)).and_then(|c| c.get("text")).and_then(|t| t.as_str())
+    let content = resp
+        .get("result")
+        .and_then(|r| r.get("content"))
+        .and_then(|c| c.as_array())
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("text"))
+        .and_then(|t| t.as_str())
         .ok_or_else(|| anyhow!("Failed to parse account_create response: {:?}", resp))?;
 
     let account_data: Value = serde_json::from_str(content)?;
-    let bootstrap_token = account_data["bootstrap_token"].as_str()
+    let bootstrap_token = account_data["bootstrap_token"]
+        .as_str()
         .ok_or_else(|| anyhow!("Missing bootstrap_token in response"))?;
 
     // 2. auth_exchange
     println!("Exchanging bootstrap token for access tokens...");
-    let resp = http_client.post(&endpoint)
+    let resp = http_client
+        .post(&endpoint)
         .header(CONTENT_TYPE, "application/json")
         .json(&json!({
             "jsonrpc": "2.0",
@@ -278,13 +300,22 @@ async fn login_flow(name: Option<String>, endpoint: String) -> Result<()> {
         .json::<Value>()
         .await?;
 
-    let content = resp.get("result").and_then(|r| r.get("content")).and_then(|c| c.as_array())
-        .and_then(|c| c.get(0)).and_then(|c| c.get("text")).and_then(|t| t.as_str())
+    let content = resp
+        .get("result")
+        .and_then(|r| r.get("content"))
+        .and_then(|c| c.as_array())
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("text"))
+        .and_then(|t| t.as_str())
         .ok_or_else(|| anyhow!("Failed to parse auth_exchange response: {:?}", resp))?;
 
     let token_data: Value = serde_json::from_str(content)?;
-    let access_token = token_data["access_token"].as_str().ok_or_else(|| anyhow!("Missing access_token"))?;
-    let refresh_token = token_data["refresh_token"].as_str().ok_or_else(|| anyhow!("Missing refresh_token"))?;
+    let access_token = token_data["access_token"]
+        .as_str()
+        .ok_or_else(|| anyhow!("Missing access_token"))?;
+    let refresh_token = token_data["refresh_token"]
+        .as_str()
+        .ok_or_else(|| anyhow!("Missing refresh_token"))?;
 
     let creds = Credentials {
         access_token: access_token.to_string(),
@@ -302,10 +333,10 @@ async fn generate_hashcash(resource: &str, bits: u32) -> Result<String> {
     let resource = resource.to_owned();
 
     let stamp = tokio::task::spawn_blocking(move || -> Result<String, anyhow::Error> {
-        use sha1::{Sha1, Digest};
         use chrono::Utc;
-        use rand::{thread_rng, Rng};
         use rand::distributions::Alphanumeric;
+        use rand::{thread_rng, Rng};
+        use sha1::{Digest, Sha1};
 
         let date = Utc::now().format("%y%m%d").to_string();
         let salt: String = thread_rng()
@@ -340,4 +371,254 @@ async fn generate_hashcash(resource: &str, bits: u32) -> Result<String> {
     .await??;
 
     Ok(stamp)
+}
+
+#[cfg(test)]
+fn verify_hashcash(stamp: &str, expected_bits: u32) -> bool {
+    use sha1::{Digest, Sha1};
+    let mut hasher = Sha1::new();
+    hasher.update(stamp.as_bytes());
+    let result = hasher.finalize();
+
+    let mut zeros = 0u32;
+    for &byte in result.iter() {
+        if byte == 0 {
+            zeros += 8;
+        } else {
+            zeros += byte.leading_zeros();
+            break;
+        }
+    }
+    zeros >= expected_bits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // --- inject_token tests ---
+
+    fn make_tools_call(tool_name: &str, arguments: Value) -> Value {
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": tool_name,
+                "arguments": arguments
+            }
+        })
+    }
+
+    #[test]
+    fn inject_token_adds_token_to_regular_tool() {
+        let mut msg = make_tools_call("get_emails", json!({"limit": 10}));
+        inject_token(&mut msg, "test-token-123");
+
+        let token = msg["params"]["arguments"]["token"].as_str().unwrap();
+        assert_eq!(token, "test-token-123");
+    }
+
+    #[test]
+    fn inject_token_preserves_existing_arguments() {
+        let mut msg = make_tools_call("get_emails", json!({"limit": 10, "folder": "inbox"}));
+        inject_token(&mut msg, "test-token");
+
+        assert_eq!(msg["params"]["arguments"]["limit"], 10);
+        assert_eq!(msg["params"]["arguments"]["folder"], "inbox");
+        assert_eq!(msg["params"]["arguments"]["token"], "test-token");
+    }
+
+    #[test]
+    fn inject_token_does_not_overwrite_existing_token() {
+        let mut msg = make_tools_call("get_emails", json!({"token": "user-provided-token"}));
+        inject_token(&mut msg, "injected-token");
+
+        let token = msg["params"]["arguments"]["token"].as_str().unwrap();
+        assert_eq!(token, "user-provided-token");
+    }
+
+    #[test]
+    fn inject_token_skips_help() {
+        let mut msg = make_tools_call("help", json!({}));
+        inject_token(&mut msg, "test-token");
+
+        assert!(msg["params"]["arguments"]["token"].is_null());
+    }
+
+    #[test]
+    fn inject_token_skips_account_create() {
+        let mut msg = make_tools_call("account_create", json!({"name": "test", "hashcash": "abc"}));
+        inject_token(&mut msg, "test-token");
+
+        assert!(msg["params"]["arguments"]["token"].is_null());
+    }
+
+    #[test]
+    fn inject_token_skips_auth_exchange() {
+        let mut msg = make_tools_call("auth_exchange", json!({"bootstrap_token": "abc"}));
+        inject_token(&mut msg, "test-token");
+
+        assert!(msg["params"]["arguments"]["token"].is_null());
+    }
+
+    #[test]
+    fn inject_token_skips_auth_refresh() {
+        let mut msg = make_tools_call("auth_refresh", json!({"refresh_token": "abc"}));
+        inject_token(&mut msg, "test-token");
+
+        assert!(msg["params"]["arguments"]["token"].is_null());
+    }
+
+    #[test]
+    fn inject_token_ignores_non_tools_call_method() {
+        let mut msg = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        });
+        let original = msg.clone();
+        inject_token(&mut msg, "test-token");
+
+        assert_eq!(msg, original);
+    }
+
+    #[test]
+    fn inject_token_ignores_notifications() {
+        let mut msg = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        });
+        let original = msg.clone();
+        inject_token(&mut msg, "test-token");
+
+        assert_eq!(msg, original);
+    }
+
+    #[test]
+    fn inject_token_handles_missing_params() {
+        let mut msg = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call"
+        });
+        let original = msg.clone();
+        inject_token(&mut msg, "test-token");
+
+        assert_eq!(msg, original);
+    }
+
+    #[test]
+    fn inject_token_handles_missing_arguments() {
+        let mut msg = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "get_emails"
+            }
+        });
+        let original = msg.clone();
+        inject_token(&mut msg, "test-token");
+
+        // No arguments object to inject into, so message unchanged
+        assert_eq!(msg, original);
+    }
+
+    #[test]
+    fn inject_token_handles_missing_name() {
+        let mut msg = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "arguments": {"foo": "bar"}
+            }
+        });
+        let original = msg.clone();
+        inject_token(&mut msg, "test-token");
+
+        assert_eq!(msg, original);
+    }
+
+    // --- Credentials tests ---
+
+    #[test]
+    fn credentials_serialization_roundtrip() {
+        let creds = Credentials {
+            access_token: "at-123".to_string(),
+            refresh_token: "rt-456".to_string(),
+            account_name: "testuser".to_string(),
+            endpoint: "https://mcp.inboxapi.ai/mcp".to_string(),
+        };
+
+        let json_str = serde_json::to_string(&creds).unwrap();
+        let deserialized: Credentials = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(deserialized.access_token, "at-123");
+        assert_eq!(deserialized.refresh_token, "rt-456");
+        assert_eq!(deserialized.account_name, "testuser");
+        assert_eq!(deserialized.endpoint, "https://mcp.inboxapi.ai/mcp");
+    }
+
+    #[test]
+    fn credentials_deserialize_from_json() {
+        let json_str = r#"{
+            "access_token": "abc",
+            "refresh_token": "def",
+            "account_name": "user1",
+            "endpoint": "https://example.com/mcp"
+        }"#;
+
+        let creds: Credentials = serde_json::from_str(json_str).unwrap();
+        assert_eq!(creds.access_token, "abc");
+        assert_eq!(creds.account_name, "user1");
+    }
+
+    #[test]
+    fn credentials_deserialize_rejects_missing_fields() {
+        let json_str = r#"{"access_token": "abc"}"#;
+        let result: Result<Credentials, _> = serde_json::from_str(json_str);
+        assert!(result.is_err());
+    }
+
+    // --- get_credentials_path tests ---
+
+    #[test]
+    fn credentials_path_ends_with_expected_components() {
+        let path = get_credentials_path().unwrap();
+        assert!(path.ends_with("inboxapi/credentials.json"));
+    }
+
+    // --- hashcash tests ---
+
+    #[tokio::test]
+    async fn generate_hashcash_produces_valid_stamp() {
+        let stamp = generate_hashcash("testuser", 8).await.unwrap();
+
+        // Verify format: 1:<bits>:<date>:<resource>::<salt>:<counter>
+        let parts: Vec<&str> = stamp.split(':').collect();
+        assert_eq!(parts[0], "1");
+        assert_eq!(parts[1], "8");
+        // parts[2] is date
+        assert_eq!(parts[3], "testuser");
+        // parts[4] is empty (between :: )
+        assert_eq!(parts[4], "");
+
+        // Verify the stamp actually satisfies the proof-of-work
+        assert!(verify_hashcash(&stamp, 8));
+    }
+
+    #[tokio::test]
+    async fn generate_hashcash_contains_resource() {
+        let stamp = generate_hashcash("myresource", 8).await.unwrap();
+        assert!(stamp.contains("myresource"));
+    }
+
+    #[test]
+    fn verify_hashcash_rejects_invalid_stamp() {
+        assert!(!verify_hashcash("not-a-valid-hashcash", 20));
+    }
 }


### PR DESCRIPTION
## Summary
- Add 5 platform-specific npm packages (`@inboxapi/cli-{darwin-arm64,darwin-x64,linux-x64,linux-arm64,win32-x64}`) with os/cpu fields for automatic platform selection
- Rewrite `index.js` with three-tier binary resolution: platform npm package → local `target/` build → `cargo run` fallback
- Extend CI workflow with `npm-publish` job that publishes all platform + root packages on tag push
- Add 19 unit tests covering `inject_token` (12 tests), `Credentials` serialization (3), `get_credentials_path` (1), and `generate_hashcash` (3)
- Rewrite `CLAUDE.md` and `GEMINI.md`, create new `AGENTS.md` for public repo contributors
- Update `.gitignore` and `package.json` for npm distribution

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo test` — 19 tests pass
- [x] All 5 platform `package.json` files verified (correct os/cpu/binary fields)
- [x] `index.js` platform resolution logic verified via Node
- [x] Release workflow YAML validated
- [ ] Manual: add `NPM_TOKEN` secret to GitHub repo settings before first tag push