### PR TITLE
feat: add reset, backup, and restore CLI subcommands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ cargo test           # Run tests
 cargo fmt            # Format Rust code
 cargo run -- proxy   # Start proxy (default subcommand)
 cargo run -- login   # Authenticate
+cargo run -- whoami  # Show current account info
+cargo run -- reset   # Delete stored credentials
+cargo run -- backup <folder>   # Back up credentials
+cargo run -- restore <folder>  # Restore credentials from backup
 ```
 
 ## Architecture
@@ -53,8 +57,15 @@ Cargo.toml                     — Rust dependencies
 - Do not add AI attribution to commits, code, or comments
 - Keep `src/main.rs` as a single file — this is a simple proxy, not a framework
 
+## Pre-completion Checklist
+Before declaring work done, run these in order:
+1. `cargo fmt` — format code
+2. `cargo clippy -- -D warnings` — lint with zero warnings
+3. `cargo test` — all unit tests pass
+4. `cargo build` — clean compilation
+
 ## Contribution Workflow
 1. Create a feature branch from `main`
 2. Implement changes with focused commits
-3. Run `cargo build && cargo test && cargo fmt --check`
+3. Run the pre-completion checklist above
 4. Open a PR against `main`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,9 @@ Rust-based STDIO proxy that bridges JSON-RPC (MCP protocol) over STDIO to the re
 - `cargo run -- proxy` — start the STDIO proxy (default)
 - `cargo run -- login` — authenticate and store credentials
 - `cargo run -- whoami` — show current account info
+- `cargo run -- reset` — delete stored credentials (with optional backup prompt)
+- `cargo run -- backup <folder>` — back up credentials to a folder
+- `cargo run -- restore <folder>` — restore credentials from a backup folder
 
 ## Architecture
 - **Single-file proxy** (`src/main.rs`): reads JSON-RPC from stdin, POSTs to remote endpoint, streams SSE responses to stdout. Injects stored access tokens into `tools/call` arguments.
@@ -32,6 +35,13 @@ Rust-based STDIO proxy that bridges JSON-RPC (MCP protocol) over STDIO to the re
 - `npm/cli-*/package.json` — platform-specific npm package manifests
 - `.github/workflows/release.yml` — cross-build + GitHub Release + npm publish
 - `Cargo.toml` — Rust dependencies
+
+## Pre-completion Checklist
+Before declaring work done, run these in order:
+1. `cargo fmt` — format code
+2. `cargo clippy -- -D warnings` — lint with zero warnings
+3. `cargo test` — all unit tests pass
+4. `cargo build` — clean compilation
 
 ## Rules
 - Do not add AI attribution to commits, code, or comments

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,18 @@ enum Commands {
     },
     /// Show current account info
     Whoami,
+    /// Delete stored credentials
+    Reset,
+    /// Back up credentials to a folder
+    Backup {
+        /// Destination folder for the backup
+        folder: String,
+    },
+    /// Restore credentials from a backup folder
+    Restore {
+        /// Source folder containing the backup
+        folder: String,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -128,6 +140,116 @@ fn save_credentials(creds: &Credentials) -> Result<()> {
     Ok(())
 }
 
+fn prompt_yes_no(prompt: &str) -> bool {
+    eprint!("{}", prompt);
+    let mut input = String::new();
+    if std::io::stdin().read_line(&mut input).is_err() {
+        return false;
+    }
+    matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
+}
+
+fn prompt_line(prompt: &str) -> Result<String> {
+    eprint!("{}", prompt);
+    let mut input = String::new();
+    std::io::stdin()
+        .read_line(&mut input)
+        .context("Failed to read input")?;
+    Ok(input.trim().to_string())
+}
+
+fn reset_credentials() -> Result<()> {
+    let creds = match load_credentials() {
+        Ok(c) => c,
+        Err(_) => {
+            println!("No credentials found.");
+            return Ok(());
+        }
+    };
+
+    println!("Account: {}", creds.account_name);
+    if let Some(ref email) = creds.email {
+        println!("Email: {}", email);
+    }
+
+    if prompt_yes_no("Back up credentials before resetting? [y/N] ") {
+        let folder = prompt_line("Backup folder path: ")?;
+        if folder.is_empty() {
+            println!("No folder provided, skipping backup.");
+        } else {
+            backup_credentials(&folder)?;
+        }
+    }
+
+    if !prompt_yes_no("Are you sure you want to reset credentials? [y/N] ") {
+        println!("Aborted.");
+        return Ok(());
+    }
+
+    for path in get_credentials_search_paths() {
+        if path.exists() {
+            std::fs::remove_file(&path)
+                .with_context(|| format!("Failed to delete {}", path.display()))?;
+            println!("Deleted: {}", path.display());
+        }
+    }
+    println!("Credentials reset.");
+    Ok(())
+}
+
+fn backup_credentials(folder: &str) -> Result<()> {
+    let creds = load_credentials()?;
+    let dest = PathBuf::from(folder);
+    std::fs::create_dir_all(&dest)
+        .with_context(|| format!("Failed to create directory {}", dest.display()))?;
+
+    let dest_file = dest.join("credentials.json");
+    let content = serde_json::to_string_pretty(&creds)?;
+
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&dest_file)?;
+        file.write_all(content.as_bytes())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&dest_file, content)?;
+    }
+
+    println!("Credentials backed up to {}", dest_file.display());
+    Ok(())
+}
+
+fn restore_credentials(folder: &str) -> Result<()> {
+    let src_file = PathBuf::from(folder).join("credentials.json");
+    let content = std::fs::read_to_string(&src_file)
+        .with_context(|| format!("Failed to read {}", src_file.display()))?;
+    let creds: Credentials = serde_json::from_str(&content)
+        .with_context(|| format!("Invalid credentials format in {}", src_file.display()))?;
+
+    if creds.access_token.trim().is_empty() || creds.refresh_token.trim().is_empty() {
+        return Err(anyhow!(
+            "Backup contains empty tokens — refusing to restore potentially corrupted credentials"
+        ));
+    }
+
+    save_credentials(&creds)?;
+
+    println!("Credentials restored for: {}", creds.account_name);
+    if let Some(ref email) = creds.email {
+        println!("Email: {}", email);
+    }
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -144,6 +266,9 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Some(Commands::Proxy { endpoint }) => run_proxy(endpoint).await,
+        Some(Commands::Reset) => reset_credentials(),
+        Some(Commands::Backup { folder }) => backup_credentials(&folder),
+        Some(Commands::Restore { folder }) => restore_credentials(&folder),
         None => {
             // Prefer the endpoint stored in credentials, if available; fall back to CLI default.
             let endpoint = match load_credentials() {
@@ -1029,7 +1154,7 @@ async fn create_account_and_authenticate(
         .get("result")
         .and_then(|r| r.get("content"))
         .and_then(|c| c.as_array())
-        .and_then(|c| c.get(0))
+        .and_then(|c| c.first())
         .and_then(|c| c.get("text"))
         .and_then(|t| t.as_str())
         .ok_or_else(|| anyhow!("Failed to parse account_create response: {:?}", resp))?;
@@ -1063,7 +1188,7 @@ async fn create_account_and_authenticate(
         .get("result")
         .and_then(|r| r.get("content"))
         .and_then(|c| c.as_array())
-        .and_then(|c| c.get(0))
+        .and_then(|c| c.first())
         .and_then(|c| c.get("text"))
         .and_then(|t| t.as_str())
         .ok_or_else(|| anyhow!("Failed to parse auth_exchange response: {:?}", resp))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,6 +204,12 @@ fn backup_credentials(folder: &str) -> Result<()> {
         .with_context(|| format!("Failed to create directory {}", dest.display()))?;
 
     let dest_file = dest.join("credentials.json");
+
+    if dest_file.exists() && !prompt_yes_no("Backup file already exists. Overwrite? [y/N] ") {
+        println!("Aborted.");
+        return Ok(());
+    }
+
     let content = serde_json::to_string_pretty(&creds)?;
 
     #[cfg(unix)]
@@ -239,6 +245,22 @@ fn restore_credentials(folder: &str) -> Result<()> {
         return Err(anyhow!(
             "Backup contains empty tokens — refusing to restore potentially corrupted credentials"
         ));
+    }
+
+    if let Ok(existing) = load_credentials() {
+        println!("Existing credentials found for: {}", existing.account_name);
+        if prompt_yes_no("Back up existing credentials before restoring? [y/N] ") {
+            let backup_folder = prompt_line("Backup folder path: ")?;
+            if backup_folder.is_empty() {
+                println!("No folder provided, skipping backup.");
+            } else {
+                backup_credentials(&backup_folder)?;
+            }
+        }
+        if !prompt_yes_no("Overwrite existing credentials? [y/N] ") {
+            println!("Aborted.");
+            return Ok(());
+        }
     }
 
     save_credentials(&creds)?;


### PR DESCRIPTION
## Summary
- Add `reset` command: deletes stored credentials with optional backup prompt and confirmation
- Add `backup <folder>` command: backs up credentials to a folder with secure `0o600` permissions on Unix
- Add `restore <folder>` command: restores credentials from a backup folder with token validation to reject corrupted backups
- Fix pre-existing clippy warnings (`c.get(0)` → `c.first()`)
- Add pre-completion checklist to CLAUDE.md and AGENTS.md (fmt → clippy → test → build)

## Test Plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — 48/48 pass
- [x] `cargo build` — compiles
- [ ] `cargo run -- reset` — prompts and deletes credentials
- [ ] `cargo run -- backup /tmp/inboxapi-backup` — backs up credentials
- [ ] `cargo run -- restore /tmp/inboxapi-backup` — restores credentials
- [ ] `cargo run -- whoami` — verify restored credentials work