### PR TITLE
chore: update GitHub references to inboxapi/cli

### DIFF
--- a/npm/cli-darwin-arm64/package.json
+++ b/npm/cli-darwin-arm64/package.json
@@ -2,14 +2,20 @@
   "name": "@inboxapi/cli-darwin-arm64",
   "version": "0.1.0",
   "description": "InboxAPI CLI binary for macOS ARM64",
-  "os": ["darwin"],
-  "cpu": ["arm64"],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
   "main": "inboxapi-cli",
-  "files": ["inboxapi-cli"],
+  "files": [
+    "inboxapi-cli"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/shaond/inboxapi-cli.git"
+    "url": "git+https://github.com/inboxapi/cli.git"
   },
   "preferUnplugged": true
 }

--- a/npm/cli-darwin-x64/package.json
+++ b/npm/cli-darwin-x64/package.json
@@ -2,14 +2,20 @@
   "name": "@inboxapi/cli-darwin-x64",
   "version": "0.1.0",
   "description": "InboxAPI CLI binary for macOS x64",
-  "os": ["darwin"],
-  "cpu": ["x64"],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
   "main": "inboxapi-cli",
-  "files": ["inboxapi-cli"],
+  "files": [
+    "inboxapi-cli"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/shaond/inboxapi-cli.git"
+    "url": "git+https://github.com/inboxapi/cli.git"
   },
   "preferUnplugged": true
 }

--- a/npm/cli-linux-arm64/package.json
+++ b/npm/cli-linux-arm64/package.json
@@ -2,14 +2,20 @@
   "name": "@inboxapi/cli-linux-arm64",
   "version": "0.1.0",
   "description": "InboxAPI CLI binary for Linux ARM64",
-  "os": ["linux"],
-  "cpu": ["arm64"],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
   "main": "inboxapi-cli",
-  "files": ["inboxapi-cli"],
+  "files": [
+    "inboxapi-cli"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/shaond/inboxapi-cli.git"
+    "url": "git+https://github.com/inboxapi/cli.git"
   },
   "preferUnplugged": true
 }

--- a/npm/cli-linux-x64/package.json
+++ b/npm/cli-linux-x64/package.json
@@ -2,14 +2,20 @@
   "name": "@inboxapi/cli-linux-x64",
   "version": "0.1.0",
   "description": "InboxAPI CLI binary for Linux x64",
-  "os": ["linux"],
-  "cpu": ["x64"],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
   "main": "inboxapi-cli",
-  "files": ["inboxapi-cli"],
+  "files": [
+    "inboxapi-cli"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/shaond/inboxapi-cli.git"
+    "url": "git+https://github.com/inboxapi/cli.git"
   },
   "preferUnplugged": true
 }

--- a/npm/cli-win32-x64/package.json
+++ b/npm/cli-win32-x64/package.json
@@ -2,14 +2,20 @@
   "name": "@inboxapi/cli-win32-x64",
   "version": "0.1.0",
   "description": "InboxAPI CLI binary for Windows x64",
-  "os": ["win32"],
-  "cpu": ["x64"],
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
   "main": "inboxapi-cli.exe",
-  "files": ["inboxapi-cli.exe"],
+  "files": [
+    "inboxapi-cli.exe"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/shaond/inboxapi-cli.git"
+    "url": "git+https://github.com/inboxapi/cli.git"
   },
   "preferUnplugged": true
 }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "bin": {
     "inboxapi": "index.js"
   },
-  "files": ["index.js"],
+  "files": [
+    "index.js"
+  ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/shaond/inboxapi-cli.git"
+    "url": "git+https://github.com/inboxapi/cli.git"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION
Replaces all references to the old GitHub repository URL (https://github.com/shaond/inboxapi-cli) with the new one (https://github.com/inboxapi/cli).