### PR TITLE
Brighten agent name generation with cheerful and playful moods

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1158,6 +1158,7 @@ fn generate_agent_name() -> String {
         ("honeybee", &[Mood::Cheerful, Mood::Playful]),
         ("puffin", &[Mood::Silly, Mood::Cute]),
         ("fawn", &[Mood::Cute, Mood::Cheerful]),
+        ("kangaroo", &[Mood::Playful, Mood::Cheerful]),
     ];
 
     // Markov transition weights: [Silly, Cheerful, Cute, Playful]
@@ -1697,6 +1698,7 @@ mod tests {
             "honeybee",
             "puffin",
             "fawn",
+            "kangaroo",
         ]
         .into_iter()
         .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1103,74 +1103,70 @@ fn generate_agent_name() -> String {
     #[derive(Clone, Copy, PartialEq)]
     enum Mood {
         Silly,
-        Dark,
+        Cheerful,
         Cute,
-        Chaotic,
+        Playful,
     }
 
-    const MOODS: [Mood; 4] = [Mood::Silly, Mood::Dark, Mood::Cute, Mood::Chaotic];
+    const MOODS: [Mood; 4] = [Mood::Silly, Mood::Cheerful, Mood::Cute, Mood::Playful];
 
     fn adjectives_for(mood: Mood) -> &'static [&'static str] {
         match mood {
             Mood::Silly => &[
                 "giggly", "wobbly", "bonkers", "goofy", "zany", "wacky", "loopy", "dizzy",
             ],
-            Mood::Dark => &[
-                "brooding",
-                "shadowy",
-                "grim",
-                "ominous",
-                "cryptic",
-                "mysterious",
-                "sinister",
-                "haunted",
+            Mood::Cheerful => &[
+                "sunny", "jolly", "bright", "merry", "chipper", "gleeful", "peppy", "radiant",
             ],
             Mood::Cute => &[
                 "fluffy", "sparkly", "cozy", "tiny", "snuggly", "precious", "dainty", "fuzzy",
             ],
-            Mood::Chaotic => &[
-                "feral",
-                "unhinged",
-                "rampaging",
-                "turbulent",
-                "volatile",
-                "frenzied",
-                "rogue",
-                "wild",
+            Mood::Playful => &[
+                "bouncy", "zippy", "frisky", "prancy", "bubbly", "perky", "spritely", "jivy",
             ],
         }
     }
 
     const ANIMALS: &[(&str, &[Mood])] = &[
         ("penguin", &[Mood::Silly, Mood::Cute]),
-        ("raccoon", &[Mood::Chaotic, Mood::Silly]),
-        ("owl", &[Mood::Dark, Mood::Cute]),
-        ("cat", &[Mood::Chaotic, Mood::Dark, Mood::Cute]),
+        ("raccoon", &[Mood::Playful, Mood::Silly]),
+        ("owl", &[Mood::Cheerful, Mood::Cute]),
+        ("cat", &[Mood::Playful, Mood::Cheerful, Mood::Cute]),
         ("capybara", &[Mood::Cute, Mood::Silly]),
-        ("crow", &[Mood::Dark, Mood::Chaotic]),
-        ("otter", &[Mood::Silly, Mood::Cute]),
-        ("wolf", &[Mood::Dark, Mood::Chaotic]),
+        ("otter", &[Mood::Silly, Mood::Playful]),
         ("hamster", &[Mood::Cute, Mood::Silly]),
-        ("fox", &[Mood::Chaotic, Mood::Dark]),
+        ("fox", &[Mood::Playful, Mood::Cheerful]),
         ("duckling", &[Mood::Cute, Mood::Silly]),
-        ("bat", &[Mood::Dark, Mood::Chaotic]),
         ("panda", &[Mood::Cute, Mood::Silly]),
-        ("raven", &[Mood::Dark]),
-        ("ferret", &[Mood::Chaotic, Mood::Silly]),
-        ("moth", &[Mood::Dark, Mood::Cute]),
+        ("ferret", &[Mood::Playful, Mood::Silly]),
         ("sloth", &[Mood::Silly, Mood::Cute]),
-        ("gecko", &[Mood::Silly, Mood::Chaotic]),
+        ("gecko", &[Mood::Silly, Mood::Playful]),
         ("hedgehog", &[Mood::Cute]),
-        ("possum", &[Mood::Chaotic, Mood::Silly]),
+        ("bunny", &[Mood::Cute, Mood::Playful]),
+        ("puppy", &[Mood::Cheerful, Mood::Playful]),
+        ("kitten", &[Mood::Cute, Mood::Playful]),
+        ("dolphin", &[Mood::Cheerful, Mood::Playful]),
+        ("butterfly", &[Mood::Cheerful, Mood::Cute]),
+        ("hummingbird", &[Mood::Cheerful, Mood::Playful]),
+        ("quokka", &[Mood::Cheerful, Mood::Silly]),
+        ("robin", &[Mood::Cheerful, Mood::Cute]),
+        ("piglet", &[Mood::Cute, Mood::Silly]),
+        ("lamb", &[Mood::Cute, Mood::Cheerful]),
+        ("chipmunk", &[Mood::Playful, Mood::Silly]),
+        ("seahorse", &[Mood::Cute, Mood::Cheerful]),
+        ("koala", &[Mood::Cute, Mood::Silly]),
+        ("honeybee", &[Mood::Cheerful, Mood::Playful]),
+        ("puffin", &[Mood::Silly, Mood::Cute]),
+        ("fawn", &[Mood::Cute, Mood::Cheerful]),
     ];
 
-    // Markov transition weights: [Silly, Dark, Cute, Chaotic]
-    // Transitions favor contrast over reinforcement for more interesting combos
+    // Markov transition weights: [Silly, Cheerful, Cute, Playful]
+    // Transitions favor complementary moods for charming combos
     const TRANSITIONS: [[f64; 4]; 4] = [
-        [0.2, 0.2, 0.3, 0.3], // Silly →
-        [0.2, 0.2, 0.3, 0.3], // Dark →
-        [0.3, 0.3, 0.2, 0.2], // Cute →
-        [0.3, 0.3, 0.2, 0.2], // Chaotic →
+        [0.15, 0.30, 0.25, 0.30], // Silly → favors Cheerful & Playful
+        [0.25, 0.15, 0.30, 0.30], // Cheerful → favors Cute & Playful
+        [0.25, 0.30, 0.15, 0.30], // Cute → favors Cheerful & Playful
+        [0.30, 0.25, 0.30, 0.15], // Playful → favors Silly & Cute
     ];
 
     let mut rng = rand::thread_rng();
@@ -1662,46 +1658,45 @@ mod tests {
     #[test]
     fn agent_name_parts_are_from_word_lists() {
         let all_adjectives: std::collections::HashSet<&str> = [
-            "giggly",
-            "wobbly",
-            "bonkers",
-            "goofy",
-            "zany",
-            "wacky",
-            "loopy",
-            "dizzy",
-            "brooding",
-            "shadowy",
-            "grim",
-            "ominous",
-            "cryptic",
-            "mysterious",
-            "sinister",
-            "haunted",
-            "fluffy",
-            "sparkly",
-            "cozy",
-            "tiny",
-            "snuggly",
-            "precious",
-            "dainty",
-            "fuzzy",
-            "feral",
-            "unhinged",
-            "rampaging",
-            "turbulent",
-            "volatile",
-            "frenzied",
-            "rogue",
-            "wild",
+            "giggly", "wobbly", "bonkers", "goofy", "zany", "wacky", "loopy", "dizzy", "sunny",
+            "jolly", "bright", "merry", "chipper", "gleeful", "peppy", "radiant", "fluffy",
+            "sparkly", "cozy", "tiny", "snuggly", "precious", "dainty", "fuzzy", "bouncy", "zippy",
+            "frisky", "prancy", "bubbly", "perky", "spritely", "jivy",
         ]
         .into_iter()
         .collect();
 
         let all_animals: std::collections::HashSet<&str> = [
-            "penguin", "raccoon", "owl", "cat", "capybara", "crow", "otter", "wolf", "hamster",
-            "fox", "duckling", "bat", "panda", "raven", "ferret", "moth", "sloth", "gecko",
-            "hedgehog", "possum",
+            "penguin",
+            "raccoon",
+            "owl",
+            "cat",
+            "capybara",
+            "otter",
+            "hamster",
+            "fox",
+            "duckling",
+            "panda",
+            "ferret",
+            "sloth",
+            "gecko",
+            "hedgehog",
+            "bunny",
+            "puppy",
+            "kitten",
+            "dolphin",
+            "butterfly",
+            "hummingbird",
+            "quokka",
+            "robin",
+            "piglet",
+            "lamb",
+            "chipmunk",
+            "seahorse",
+            "koala",
+            "honeybee",
+            "puffin",
+            "fawn",
         ]
         .into_iter()
         .collect();


### PR DESCRIPTION
## Summary
Replaced the darker mood themes in agent name generation with more positive and uplifting alternatives, creating a friendlier overall tone for generated agent names.

## Key Changes
- **Mood enum overhaul**: Replaced `Dark` and `Chaotic` moods with `Cheerful` and `Playful` respectively
- **Adjective updates**: 
  - Replaced dark-themed adjectives (brooding, shadowy, grim, ominous, etc.) with cheerful ones (sunny, jolly, bright, merry, etc.)
  - Replaced chaotic-themed adjectives (feral, unhinged, rampaging, volatile, etc.) with playful ones (bouncy, zippy, frisky, bubbly, etc.)
- **Animal roster expansion**: Added 15 new animals (bunny, puppy, kitten, dolphin, butterfly, hummingbird, quokka, robin, piglet, lamb, chipmunk, seahorse, koala, honeybee, puffin, fawn) while removing darker-themed animals (crow, wolf, bat, raven, moth, possum)
- **Mood associations**: Updated all animal-mood pairings to use the new mood types
- **Markov transition matrix**: Refined transition weights to favor complementary mood combinations that create more charming name pairings
- **Test updates**: Updated test fixtures to reflect the new adjectives and animals

## Implementation Details
The transition matrix was adjusted to create more intentional mood progressions:
- Silly now favors Cheerful and Playful transitions
- Cheerful favors Cute and Playful transitions  
- Cute favors Cheerful and Playful transitions
- Playful favors Silly and Cute transitions

This creates a more cohesive and positive naming experience while maintaining variety through the Markov chain approach.

https://claude.ai/code/session_01MaAvvurvuoUzkDSaZhp43K