### PR TITLE
feat: add Claude Code skills and hooks with setup-skills command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "inboxapi-cli"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inboxapi-cli"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2021"
 
 [dependencies]

--- a/claude/hooks/credential-check.js
+++ b/claude/hooks/credential-check.js
@@ -5,7 +5,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const { execSync } = require("child_process");
+
 
 function findCredentials() {
   const home = process.env.HOME || process.env.USERPROFILE || "";

--- a/claude/hooks/credential-check.js
+++ b/claude/hooks/credential-check.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// InboxAPI Credential Check — SessionStart hook
+// Verifies InboxAPI credentials are present and valid on session startup.
+// Always exits 0 (non-blocking, informational only)
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+function findCredentials() {
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  const candidates = [];
+
+  // Platform config dir
+  if (process.platform === "darwin") {
+    candidates.push(
+      path.join(home, "Library", "Application Support", "inboxapi", "credentials.json"),
+    );
+  }
+  candidates.push(path.join(home, ".config", "inboxapi", "credentials.json"));
+  candidates.push(
+    path.join(home, ".local", "inboxapi", "credentials.json"),
+  );
+
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      return p;
+    }
+  }
+  return null;
+}
+
+function main() {
+  const credPath = findCredentials();
+
+  if (!credPath) {
+    process.stderr.write(
+      "\n[InboxAPI] No credentials found. Run `npx -y @inboxapi/cli login` to authenticate.\n\n",
+    );
+    process.exit(0);
+  }
+
+  try {
+    const creds = JSON.parse(fs.readFileSync(credPath, "utf8"));
+    const email = creds.email || creds.account_name || "(unknown)";
+    process.stderr.write(
+      `\n[InboxAPI] Authenticated as: ${email}\n\n`,
+    );
+  } catch {
+    process.stderr.write(
+      "\n[InboxAPI] Credentials file exists but could not be read. Run `npx -y @inboxapi/cli login` to re-authenticate.\n\n",
+    );
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/claude/hooks/credential-check.js
+++ b/claude/hooks/credential-check.js
@@ -17,6 +17,12 @@ function findCredentials() {
       path.join(home, "Library", "Application Support", "inboxapi", "credentials.json"),
     );
   }
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA || "";
+    const localAppData = process.env.LOCALAPPDATA || "";
+    if (appData) candidates.push(path.join(appData, "inboxapi", "credentials.json"));
+    if (localAppData) candidates.push(path.join(localAppData, "inboxapi", "credentials.json"));
+  }
   candidates.push(path.join(home, ".config", "inboxapi", "credentials.json"));
   candidates.push(
     path.join(home, ".local", "inboxapi", "credentials.json"),

--- a/claude/hooks/credential-check.js
+++ b/claude/hooks/credential-check.js
@@ -9,6 +9,7 @@ const path = require("path");
 
 function findCredentials() {
   const home = process.env.HOME || process.env.USERPROFILE || "";
+  if (!home) return null;
   const candidates = [];
 
   // Platform config dir

--- a/claude/hooks/email-activity-logger.js
+++ b/claude/hooks/email-activity-logger.js
@@ -27,7 +27,7 @@ function main() {
   const timestamp = new Date().toISOString();
   const shortName = toolName.replace("mcp__inboxapi__", "");
 
-  // Build a concise, privacy-preserving log entry (no PII in log output)
+  // Build a concise log entry (logs identifiers and lengths, not email content)
   let details = "";
   switch (shortName) {
     case "send_email": {

--- a/claude/hooks/email-activity-logger.js
+++ b/claude/hooks/email-activity-logger.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// InboxAPI Activity Logger — PostToolUse hook
+// Logs all InboxAPI MCP tool usage to .claude/inboxapi-activity.log
+// Always exits 0 (non-blocking)
+
+const fs = require("fs");
+const path = require("path");
+
+function main() {
+  const input = fs.readFileSync("/dev/stdin", "utf8");
+  let data;
+  try {
+    data = JSON.parse(input);
+  } catch {
+    process.exit(0);
+  }
+
+  const toolName = data.tool_name || "";
+  const toolInput = data.tool_input || {};
+  const cwd = data.cwd || process.cwd();
+
+  // Only log inboxapi tools
+  if (!toolName.includes("inboxapi")) {
+    process.exit(0);
+  }
+
+  const timestamp = new Date().toISOString();
+  const shortName = toolName.replace("mcp__inboxapi__", "");
+
+  // Build a concise log entry based on the tool type
+  let details = "";
+  switch (shortName) {
+    case "send_email":
+      details = `to=${toolInput.to || "?"}, subject="${toolInput.subject || "?"}"`;
+      break;
+    case "send_reply":
+      details = `email_id=${toolInput.email_id || "?"}, body_length=${(toolInput.body || "").length}`;
+      break;
+    case "forward_email":
+      details = `email_id=${toolInput.email_id || "?"}, to=${toolInput.to || "?"}`;
+      break;
+    case "get_email":
+      details = `email_id=${toolInput.email_id || "?"}`;
+      break;
+    case "get_emails":
+      details = `limit=${toolInput.limit || "default"}`;
+      break;
+    case "search_emails":
+      details = `query="${toolInput.query || "?"}"`;
+      break;
+    case "get_thread":
+      details = `thread_id=${toolInput.thread_id || "?"}`;
+      break;
+    default:
+      details = JSON.stringify(toolInput).substring(0, 200);
+  }
+
+  const logLine = `[${timestamp}] ${shortName}: ${details}\n`;
+
+  // Write to log file
+  const logPath = path.join(cwd, ".claude", "inboxapi-activity.log");
+  try {
+    const logDir = path.dirname(logPath);
+    if (!fs.existsSync(logDir)) {
+      fs.mkdirSync(logDir, { recursive: true });
+    }
+    fs.appendFileSync(logPath, logLine);
+  } catch {
+    // Non-critical — don't fail the tool call
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/claude/hooks/email-activity-logger.js
+++ b/claude/hooks/email-activity-logger.js
@@ -7,7 +7,7 @@ const fs = require("fs");
 const path = require("path");
 
 function main() {
-  const input = fs.readFileSync("/dev/stdin", "utf8");
+  const input = fs.readFileSync(0, "utf8");
   let data;
   try {
     data = JSON.parse(input);
@@ -51,8 +51,11 @@ function main() {
     case "get_thread":
       details = `thread_id=${toolInput.thread_id || "?"}`;
       break;
-    default:
-      details = JSON.stringify(toolInput).substring(0, 200);
+    default: {
+      const keys = toolInput && typeof toolInput === "object" ? Object.keys(toolInput) : [];
+      details = keys.length ? `fields=${keys.join(",")}` : "fields=<none>";
+      break;
+    }
   }
 
   const logLine = `[${timestamp}] ${shortName}: ${details}\n`;

--- a/claude/hooks/email-activity-logger.js
+++ b/claude/hooks/email-activity-logger.js
@@ -27,29 +27,35 @@ function main() {
   const timestamp = new Date().toISOString();
   const shortName = toolName.replace("mcp__inboxapi__", "");
 
-  // Build a concise log entry based on the tool type
+  // Build a concise, privacy-preserving log entry (no PII in log output)
   let details = "";
   switch (shortName) {
-    case "send_email":
-      details = `to=${toolInput.to || "?"}, subject="${toolInput.subject || "?"}"`;
+    case "send_email": {
+      const toVal = toolInput.to;
+      const toCount = Array.isArray(toVal) ? toVal.length : toVal ? 1 : 0;
+      details = `to_count=${toCount}, subject_length=${(toolInput.subject || "").length}, body_length=${(toolInput.body || "").length}`;
       break;
+    }
     case "send_reply":
-      details = `email_id=${toolInput.email_id || "?"}, body_length=${(toolInput.body || "").length}`;
+      details = `in_reply_to=${toolInput.in_reply_to || "?"}, body_length=${(toolInput.body || "").length}`;
       break;
-    case "forward_email":
-      details = `email_id=${toolInput.email_id || "?"}, to=${toolInput.to || "?"}`;
+    case "forward_email": {
+      const fwdTo = toolInput.to;
+      const fwdCount = Array.isArray(fwdTo) ? fwdTo.length : fwdTo ? 1 : 0;
+      details = `message_id=${toolInput.message_id || "?"}, to_count=${fwdCount}`;
       break;
+    }
     case "get_email":
-      details = `email_id=${toolInput.email_id || "?"}`;
+      details = `index=${toolInput.index ?? "?"}, message_id=${toolInput.message_id || "?"}`;
       break;
     case "get_emails":
       details = `limit=${toolInput.limit || "default"}`;
       break;
     case "search_emails":
-      details = `query="${toolInput.query || "?"}"`;
+      details = `query_length=${(toolInput.query || toolInput.subject || toolInput.sender || "").length}`;
       break;
     case "get_thread":
-      details = `thread_id=${toolInput.thread_id || "?"}`;
+      details = `message_id=${toolInput.message_id || "?"}`;
       break;
     default: {
       const keys = toolInput && typeof toolInput === "object" ? Object.keys(toolInput) : [];

--- a/claude/hooks/email-send-guard.js
+++ b/claude/hooks/email-send-guard.js
@@ -26,7 +26,9 @@ function main() {
     process.exit(0);
   }
 
-  const to = toolInput.to || toolInput.recipient || "(unknown)";
+  const rawTo = toolInput.to || toolInput.recipient || "(unknown)";
+  const toList = Array.isArray(rawTo) ? rawTo : [rawTo];
+  const toDisplay = toList.join(", ");
   const subject = toolInput.subject || "(no subject)";
   const body = toolInput.body || toolInput.message || "";
   const action = toolName.includes("forward")
@@ -37,7 +39,7 @@ function main() {
 
   // Log details to stderr so the user sees them in the Claude Code UI
   process.stderr.write(`\n[InboxAPI Send Guard] ${action}\n`);
-  process.stderr.write(`  To:      ${to}\n`);
+  process.stderr.write(`  To:      ${toDisplay}\n`);
   process.stderr.write(`  Subject: ${subject}\n`);
   if (body.length > 0) {
     const preview = body.length > 200 ? body.substring(0, 200) + "..." : body;
@@ -46,8 +48,10 @@ function main() {
   process.stderr.write("\n");
 
   // Check for self-send (common AI agent mistake)
-  if (to.includes("@inboxapi.ai") || to.includes("@inboxapi.com")) {
-    // This might be intentional, but warn
+  const hasInboxApiRecipient = toList.some(
+    (addr) => typeof addr === "string" && (addr.includes("@inboxapi.ai") || addr.includes("@inboxapi.com")),
+  );
+  if (hasInboxApiRecipient) {
     process.stderr.write(
       `  [WARNING] Recipient is an @inboxapi address. Did you mean to send to an external address?\n\n`,
     );

--- a/claude/hooks/email-send-guard.js
+++ b/claude/hooks/email-send-guard.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 // InboxAPI Email Send Guard — PreToolUse hook
 // Reviews outbound emails before sending. Logs details to stderr for user visibility.
-// Exit 0 = allow, Exit 2 = block
+// Exit 0 = allow
 
 const fs = require("fs");
 
 function main() {
-  const input = fs.readFileSync("/dev/stdin", "utf8");
+  const input = fs.readFileSync(0, "utf8");
   let data;
   try {
     data = JSON.parse(input);

--- a/claude/hooks/email-send-guard.js
+++ b/claude/hooks/email-send-guard.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// InboxAPI Email Send Guard — PreToolUse hook
+// Reviews outbound emails before sending. Logs details to stderr for user visibility.
+// Exit 0 = allow, Exit 2 = block
+
+const fs = require("fs");
+
+function main() {
+  const input = fs.readFileSync("/dev/stdin", "utf8");
+  let data;
+  try {
+    data = JSON.parse(input);
+  } catch {
+    process.exit(0);
+  }
+
+  const toolName = data.tool_name || "";
+  const toolInput = data.tool_input || {};
+
+  // Only inspect send-related tools
+  if (
+    !toolName.includes("send_email") &&
+    !toolName.includes("send_reply") &&
+    !toolName.includes("forward_email")
+  ) {
+    process.exit(0);
+  }
+
+  const to = toolInput.to || toolInput.recipient || "(unknown)";
+  const subject = toolInput.subject || "(no subject)";
+  const body = toolInput.body || toolInput.message || "";
+  const action = toolName.includes("forward")
+    ? "FORWARD"
+    : toolName.includes("reply")
+      ? "REPLY"
+      : "SEND";
+
+  // Log details to stderr so the user sees them in the Claude Code UI
+  process.stderr.write(`\n[InboxAPI Send Guard] ${action}\n`);
+  process.stderr.write(`  To:      ${to}\n`);
+  process.stderr.write(`  Subject: ${subject}\n`);
+  if (body.length > 0) {
+    const preview = body.length > 200 ? body.substring(0, 200) + "..." : body;
+    process.stderr.write(`  Body:    ${preview}\n`);
+  }
+  process.stderr.write("\n");
+
+  // Check for self-send (common AI agent mistake)
+  if (to.includes("@inboxapi.ai") || to.includes("@inboxapi.com")) {
+    // This might be intentional, but warn
+    process.stderr.write(
+      `  [WARNING] Recipient is an @inboxapi address. Did you mean to send to an external address?\n\n`,
+    );
+  }
+
+  // Check for empty body
+  if (body.trim().length === 0) {
+    process.stderr.write(`  [WARNING] Email body is empty.\n\n`);
+  }
+
+  // Allow by default — the user sees the preview and can deny via Claude Code's permission prompt
+  process.exit(0);
+}
+
+main();

--- a/claude/skills/check-inbox/SKILL.md
+++ b/claude/skills/check-inbox/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: check-inbox
+description: Check your InboxAPI email inbox and display a summary of recent messages. Use when the user wants to see their emails, check mail, or view their inbox.
+user-invocable: true
+argument-hint: [limit]
+---
+
+# Check Inbox
+
+Fetch and display a summary of recent emails from the user's InboxAPI inbox.
+
+## Steps
+
+1. Call the `mcp__inboxapi__whoami` tool to identify the current account and email address
+2. Call `mcp__inboxapi__get_email_count` to show the total number of emails
+3. Call `mcp__inboxapi__get_emails` with:
+   - `limit`: Use `$ARGUMENTS` if provided, otherwise default to `20`
+4. Present results in a formatted table with columns:
+   - **From** — sender name or address
+   - **Subject** — email subject line (truncated to 60 chars)
+   - **Date** — received date in relative format (e.g., "2 hours ago", "yesterday")
+5. After the table, show a summary line: "Showing X of Y emails for <email>"
+
+## Output Format
+
+Use this markdown table format:
+
+```
+| # | From | Subject | Date |
+|---|------|---------|------|
+| 1 | Alice <alice@example.com> | Re: Project update... | 2h ago |
+```
+
+If the inbox is empty, display: "Your inbox is empty. Your email address is <email>."
+
+## Notes
+
+- Do NOT read full email bodies — only show the summary list
+- If the user asks to read a specific email after seeing the list, use `mcp__inboxapi__get_email` with the email ID

--- a/claude/skills/compose/SKILL.md
+++ b/claude/skills/compose/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: compose
+description: Compose and send an email with guided prompts, addressbook lookup, and send confirmation. Use when the user wants to write and send an email.
+user-invocable: true
+disable-model-invocation: true
+argument-hint: [recipient]
+---
+
+# Compose Email
+
+Guide the user through composing and sending an email safely.
+
+## Steps
+
+1. **Identify sender**: Call `mcp__inboxapi__whoami` to get the current account email address
+
+2. **Resolve recipient**:
+   - If `$ARGUMENTS` is provided, use it as the recipient hint
+   - Call `mcp__inboxapi__get_addressbook` to check for matching contacts
+   - If multiple matches found, ask the user to pick one
+   - If no match, ask the user to confirm or provide the full email address
+
+3. **Collect email details**: Ask the user for:
+   - **To**: Recipient email (pre-filled if resolved above)
+   - **Subject**: Email subject line
+   - **Body**: Email content (plain text)
+
+4. **Preview**: Show the complete email before sending:
+   ```
+   From: <your-email@inboxapi.ai>
+   To: <recipient@example.com>
+   Subject: <subject>
+   ---
+   <body>
+   ```
+
+5. **Safety checks**:
+   - Warn if the recipient address matches the sender's own @inboxapi.ai address
+   - Warn if the body is empty
+   - Warn if the subject is empty
+
+6. **Confirm**: Ask the user to confirm: "Send this email? (yes/no)"
+
+7. **Send**: Call `mcp__inboxapi__send_email` with `to`, `subject`, and `body`
+
+8. **Confirm delivery**: Report the result to the user
+
+## Rules
+
+- ALWAYS show a preview before sending
+- ALWAYS ask for explicit confirmation before calling send_email
+- NEVER send an email without the user confirming
+- If the user cancels, acknowledge and do not send

--- a/claude/skills/email-digest/SKILL.md
+++ b/claude/skills/email-digest/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: email-digest
+description: Generate a digest summary of recent email activity grouped by thread. Use when the user wants an overview of their email activity.
+user-invocable: true
+argument-hint: [timeframe]
+---
+
+# Email Digest
+
+Generate a structured digest of recent email activity.
+
+## Steps
+
+1. **Determine timeframe**: Use `$ARGUMENTS` if provided (e.g., "today", "this week", "last 3 days"), otherwise default to "last 24 hours"
+
+2. **Get account info**: Call `mcp__inboxapi__whoami` for the account email
+
+3. **Get total count**: Call `mcp__inboxapi__get_email_count` for inbox statistics
+
+4. **Fetch recent emails**: Call `mcp__inboxapi__get_emails` with an appropriate limit (50 for digest)
+
+5. **Group by thread**: For threads with multiple emails, call `mcp__inboxapi__get_thread` to understand the conversation
+
+6. **Generate digest** with these sections:
+
+   ```markdown
+   # Email Digest — <timeframe>
+   Account: <email>
+
+   ## Summary
+   - Total emails in inbox: X
+   - Emails in this period: Y
+   - Unique senders: Z
+   - Threads with activity: N
+
+   ## Active Threads
+   ### 1. <Subject>
+   - Participants: alice@..., bob@...
+   - Messages in period: 3
+   - Latest: "Brief preview of most recent message..."
+   - Status: Awaiting your reply / You replied / FYI only
+
+   ## New Emails (not in threads)
+   | From | Subject | Date |
+   |------|---------|------|
+   | ... | ... | ... |
+
+   ## Needs Attention
+   - Emails you haven't replied to where you were directly addressed
+   ```
+
+7. **Offer actions**: "Would you like to reply to any of these, or read a specific email?"
+
+## Notes
+
+- Focus on actionable insights, not raw data
+- Highlight emails that likely need a response
+- Keep the digest concise — summarize, don't reproduce full emails

--- a/claude/skills/email-forward/SKILL.md
+++ b/claude/skills/email-forward/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: email-forward
+description: Forward an email to someone with an optional message. Use when the user wants to forward a specific email to another person.
+user-invocable: true
+disable-model-invocation: true
+argument-hint: [email-id or subject]
+---
+
+# Email Forward
+
+Help the user forward an email to another recipient.
+
+## Steps
+
+1. **Find the email to forward**:
+   - If `$ARGUMENTS` looks like an email ID, call `mcp__inboxapi__get_email` directly
+   - Otherwise, call `mcp__inboxapi__search_emails` with the argument
+   - If multiple results, show them and ask the user to pick one
+
+2. **Show email content**: Display the email being forwarded:
+   ```
+   --- Email to forward ---
+   From: <original sender>
+   Subject: <subject>
+   Date: <date>
+   ---
+   <body preview, first 500 chars>
+   ```
+
+3. **Resolve recipient**:
+   - Ask "Who do you want to forward this to?"
+   - Call `mcp__inboxapi__get_addressbook` to check for matching contacts
+   - Confirm the recipient email address
+
+4. **Optional message**: Ask "Add a message? (or press enter to skip)"
+
+5. **Preview**:
+   ```
+   Forwarding to: <recipient>
+   Subject: Fwd: <original subject>
+   Your message: <optional message or "(none)">
+   Original email from: <sender>, <date>
+   ```
+
+6. **Confirm**: Ask "Forward this email? (yes/no)"
+
+7. **Send**: Call `mcp__inboxapi__forward_email` with the email ID, recipient, and optional message
+
+## Rules
+
+- ALWAYS show what's being forwarded before sending
+- ALWAYS confirm before forwarding
+- NEVER forward without explicit user confirmation

--- a/claude/skills/email-reply/SKILL.md
+++ b/claude/skills/email-reply/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: email-reply
+description: Reply to an email with full thread context. Use when the user wants to reply to a specific email or continue an email conversation.
+user-invocable: true
+disable-model-invocation: true
+argument-hint: [email-id or subject]
+---
+
+# Email Reply
+
+Help the user reply to an email with full thread context.
+
+## Steps
+
+1. **Find the email**:
+   - If `$ARGUMENTS` looks like an email ID (alphanumeric string), call `mcp__inboxapi__get_email` directly
+   - Otherwise, call `mcp__inboxapi__search_emails` with the argument as subject/keyword
+   - If multiple results, present them and ask the user to pick one
+
+2. **Load thread context**: Call `mcp__inboxapi__get_thread` with the email's thread ID to show the full conversation
+
+3. **Display thread**: Show the conversation history in chronological order:
+   ```
+   --- Thread: <subject> ---
+
+   [1] From: alice@example.com (Jan 15, 2:30 PM)
+   > Original message text...
+
+   [2] From: you@inboxapi.ai (Jan 15, 3:00 PM)
+   > Your previous reply...
+
+   [3] From: alice@example.com (Jan 15, 4:15 PM)
+   > Latest message you're replying to...
+   ```
+
+4. **Compose reply**: Ask the user what they want to say in their reply
+
+5. **Preview**: Show the reply before sending:
+   ```
+   Replying to: alice@example.com
+   Subject: Re: <subject>
+   ---
+   <reply body>
+   ```
+
+6. **Confirm**: Ask "Send this reply? (yes/no)"
+
+7. **Send**: Call `mcp__inboxapi__send_reply` with the email ID and reply body
+
+## Rules
+
+- ALWAYS show the thread context before composing
+- ALWAYS preview and confirm before sending
+- NEVER send without explicit user confirmation

--- a/claude/skills/email-search/SKILL.md
+++ b/claude/skills/email-search/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: email-search
+description: Search your InboxAPI emails using natural language. Use when the user wants to find specific emails by sender, subject, date, or content.
+user-invocable: true
+argument-hint: [query]
+---
+
+# Email Search
+
+Search emails using natural language and present results clearly.
+
+## Steps
+
+1. Take the user's query from `$ARGUMENTS`
+   - If no arguments provided, ask: "What are you looking for?"
+
+2. Translate the natural language query into a `mcp__inboxapi__search_emails` call:
+   - Extract sender hints (e.g., "from John" -> search by sender)
+   - Extract subject hints (e.g., "about invoices" -> search by subject)
+   - Extract date hints (e.g., "last week", "yesterday")
+   - Use the full query as the search term
+
+3. Call `mcp__inboxapi__search_emails` with the interpreted parameters
+
+4. Present results in a formatted table:
+   ```
+   | # | From | Subject | Date |
+   |---|------|---------|------|
+   ```
+
+5. After showing results, offer: "Would you like to read any of these emails? Provide the number."
+
+6. If the user picks one, call `mcp__inboxapi__get_email` with the email ID
+
+7. If no results, suggest alternative searches or broader terms
+
+## Examples
+
+- `/email-search invoices from accounting` -> search for "invoices" filtered by sender containing "accounting"
+- `/email-search meeting tomorrow` -> search for "meeting" in recent emails
+- `/email-search` -> prompt user for search query

--- a/claude/skills/setup-inboxapi/SKILL.md
+++ b/claude/skills/setup-inboxapi/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: setup-inboxapi
+description: Set up InboxAPI email tools in your Claude Code project. Adds MCP server config, installs skills, and configures safety hooks. Use when the user wants to configure InboxAPI for their project.
+user-invocable: true
+disable-model-invocation: true
+---
+
+# Setup InboxAPI
+
+Configure InboxAPI email tools for this Claude Code project.
+
+## Steps
+
+1. **Check current setup**: Look for existing `.mcp.json` and `.claude/settings.json` files
+
+2. **Add MCP server** (if not already configured):
+   - Check if `.mcp.json` exists and contains an `inboxapi` entry
+   - If not, run: `claude mcp add inboxapi -- npx -y @inboxapi/cli`
+   - Or create/update `.mcp.json` with:
+     ```json
+     {
+       "mcpServers": {
+         "inboxapi": {
+           "command": "npx",
+           "args": ["-y", "@inboxapi/cli"]
+         }
+       }
+     }
+     ```
+
+3. **Install skills**: Run `npx -y @inboxapi/cli setup-skills` to copy bundled skills and hooks into the project's `.claude/` directory
+
+4. **Verify credentials**:
+   - Call `mcp__inboxapi__whoami` to check if credentials are set up
+   - If not authenticated, instruct the user: "Run `npx -y @inboxapi/cli login` in a terminal to authenticate"
+
+5. **Show summary**:
+   ```
+   InboxAPI Setup Complete!
+
+   MCP Server: configured in .mcp.json
+   Email: <email> (or "not authenticated yet")
+
+   Installed Skills:
+     /check-inbox  — View inbox summary
+     /compose      — Write and send emails
+     /email-search — Search emails
+     /email-reply  — Reply with thread context
+     /email-digest — Email activity digest
+     /email-forward — Forward emails
+
+   Installed Hooks:
+     PreToolUse  — Email send guard (reviews before sending)
+     PostToolUse — Activity logger (audit trail)
+     SessionStart — Credential check (verifies auth on startup)
+
+   Next steps:
+     - Run /check-inbox to see your emails
+     - Run /compose to send your first email
+   ```
+
+## Notes
+
+- This skill is safe to run multiple times — it won't duplicate entries
+- Existing `.mcp.json` and `.claude/settings.json` entries are preserved

--- a/claude/skills/setup-inboxapi/SKILL.md
+++ b/claude/skills/setup-inboxapi/SKILL.md
@@ -61,5 +61,6 @@ Configure InboxAPI email tools for this Claude Code project.
 
 ## Notes
 
-- This skill is safe to run multiple times — it won't duplicate entries
-- Existing `.mcp.json` and `.claude/settings.json` entries are preserved
+- This skill is safe to run multiple times — it won't duplicate entries or overwrite local edits
+- Existing `.mcp.json`, `.claude/settings.json`, skill files, and hook files are preserved
+- Files with local edits are skipped; unmodified files are reported as up to date

--- a/claude/skills/setup-inboxapi/SKILL.md
+++ b/claude/skills/setup-inboxapi/SKILL.md
@@ -62,5 +62,6 @@ Configure InboxAPI email tools for this Claude Code project.
 ## Notes
 
 - This skill is safe to run multiple times — it won't duplicate entries or overwrite local edits
-- Existing `.mcp.json`, `.claude/settings.json`, skill files, and hook files are preserved
+- Existing `.mcp.json` entries, skill files, and hook files with local edits are preserved
+- `.claude/settings.json` is merged with new hook config (may be reformatted when hooks are updated)
 - Files with local edits are skipped; unmodified files are reported as up to date

--- a/npm/cli-darwin-arm64/package.json
+++ b/npm/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-darwin-arm64",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "InboxAPI CLI binary for macOS ARM64",
   "os": [
     "darwin"

--- a/npm/cli-darwin-x64/package.json
+++ b/npm/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-darwin-x64",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "InboxAPI CLI binary for macOS x64",
   "os": [
     "darwin"

--- a/npm/cli-linux-arm64/package.json
+++ b/npm/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-linux-arm64",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "InboxAPI CLI binary for Linux ARM64",
   "os": [
     "linux"

--- a/npm/cli-linux-x64/package.json
+++ b/npm/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-linux-x64",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "InboxAPI CLI binary for Linux x64",
   "os": [
     "linux"

--- a/npm/cli-win32-x64/package.json
+++ b/npm/cli-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-win32-x64",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "InboxAPI CLI binary for Windows x64",
   "os": [
     "win32"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "inboxapi": "index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "claude"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "📧 Email for your AI 🤖",
   "main": "index.js",
   "bin": {
@@ -35,6 +35,6 @@
     "@inboxapi/cli-win32-x64": "0.1.0"
   },
   "dependencies": {
-    "@inboxapi/cli": "^0.2.17"
+    "@inboxapi/cli": "^0.2.18"
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,8 @@ enum Commands {
     },
     /// Install Claude Code skills and hooks into the current project
     SetupSkills {
-        /// Overwrite existing skill and hook files even if they have local edits
+        /// Overwrite existing skill and hook files even if they have local edits.
+        /// Note: .claude/settings.json is always merged (not overwritten) regardless of this flag.
         #[arg(long)]
         force: bool,
     },
@@ -605,10 +606,16 @@ fn merge_hook_settings(settings_path: &Path) -> Result<String> {
                             .and_then(|m| m.as_str())
                             .unwrap_or("");
 
-                        // Find existing entry with the same matcher
-                        let existing_match = existing_arr.iter_mut().find(|e| {
-                            e.get("matcher").and_then(|m| m.as_str()).unwrap_or("") == matcher
-                        });
+                        // Only merge by matcher when the new entry has a non-empty matcher;
+                        // entries without a matcher are always appended to avoid
+                        // incorrectly merging unrelated hook entries together.
+                        let existing_match = if matcher.is_empty() {
+                            None
+                        } else {
+                            existing_arr.iter_mut().find(|e| {
+                                e.get("matcher").and_then(|m| m.as_str()).unwrap_or("") == matcher
+                            })
+                        };
 
                         if let Some(existing_entry) = existing_match {
                             // Merge hooks at the individual command level

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,12 +485,26 @@ static HOOKS_SETTINGS: &str = r#"{
 fn setup_skills() -> Result<()> {
     let base = PathBuf::from(".claude");
 
-    // Write skills
+    // Write skills (skip if on-disk content already matches)
     for (name, content) in SKILLS {
         let dir = base.join("skills").join(name);
         std::fs::create_dir_all(&dir)
             .with_context(|| format!("Failed to create directory {}", dir.display()))?;
         let path = dir.join("SKILL.md");
+        if path.exists() {
+            let existing = std::fs::read_to_string(&path)
+                .with_context(|| format!("Failed to read existing {}", path.display()))?;
+            if existing == *content {
+                println!("  Up to date:      /{}  ({})", name, path.display());
+                continue;
+            }
+            println!(
+                "  Skipped (local edits detected): /{}  ({})",
+                name,
+                path.display()
+            );
+            continue;
+        }
         std::fs::write(&path, content)
             .with_context(|| format!("Failed to write {}", path.display()))?;
         println!("  Installed skill: /{}  ({})", name, path.display());
@@ -527,12 +541,25 @@ fn merge_hook_settings(settings_path: &PathBuf) -> Result<String> {
     let mut existing: Value = if settings_path.exists() {
         let content = std::fs::read_to_string(settings_path)
             .with_context(|| format!("Failed to read {}", settings_path.display()))?;
-        serde_json::from_str(&content).unwrap_or_else(|_| json!({}))
+        serde_json::from_str(&content).with_context(|| {
+            format!(
+                "Failed to parse existing settings from {}",
+                settings_path.display()
+            )
+        })?
     } else {
         json!({})
     };
 
-    // Merge hooks: for each event type, append our hook entries if not already present
+    // Ensure root is an object
+    if !existing.is_object() {
+        anyhow::bail!(
+            "{} is not a JSON object — cannot merge hook settings",
+            settings_path.display()
+        );
+    }
+
+    // Merge hooks: for each event type, merge at the individual hook level
     if let Some(new_hooks) = new_settings.get("hooks").and_then(|h| h.as_object()) {
         let existing_hooks = existing
             .as_object_mut()
@@ -542,19 +569,54 @@ fn merge_hook_settings(settings_path: &PathBuf) -> Result<String> {
         if let Some(existing_hooks_obj) = existing_hooks.as_object_mut() {
             for (event, new_entries) in new_hooks {
                 let existing_entries = existing_hooks_obj.entry(event).or_insert_with(|| json!([]));
+                // Coerce non-array values into an array
+                if !existing_entries.is_array() {
+                    let previous_value = existing_entries.clone();
+                    *existing_entries = json!([previous_value]);
+                }
                 if let (Some(existing_arr), Some(new_arr)) =
                     (existing_entries.as_array_mut(), new_entries.as_array())
                 {
                     for new_entry in new_arr {
-                        // Check if an entry with the same matcher already exists
                         let matcher = new_entry
                             .get("matcher")
                             .and_then(|m| m.as_str())
                             .unwrap_or("");
-                        let already_exists = existing_arr.iter().any(|e| {
+
+                        // Find existing entry with the same matcher
+                        let existing_match = existing_arr.iter_mut().find(|e| {
                             e.get("matcher").and_then(|m| m.as_str()).unwrap_or("") == matcher
                         });
-                        if !already_exists {
+
+                        if let Some(existing_entry) = existing_match {
+                            // Merge hooks at the individual command level
+                            if let Some(new_hooks_arr) =
+                                new_entry.get("hooks").and_then(|h| h.as_array())
+                            {
+                                let entry_hooks = existing_entry
+                                    .as_object_mut()
+                                    .map(|obj| obj.entry("hooks").or_insert_with(|| json!([])));
+                                if let Some(entry_hooks_val) = entry_hooks {
+                                    if let Some(entry_hooks_arr) = entry_hooks_val.as_array_mut() {
+                                        for new_hook in new_hooks_arr {
+                                            let new_cmd = new_hook
+                                                .get("command")
+                                                .and_then(|c| c.as_str())
+                                                .unwrap_or("");
+                                            let hook_exists = entry_hooks_arr.iter().any(|h| {
+                                                h.get("command")
+                                                    .and_then(|c| c.as_str())
+                                                    .unwrap_or("")
+                                                    == new_cmd
+                                            });
+                                            if !hook_exists {
+                                                entry_hooks_arr.push(new_hook.clone());
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
                             existing_arr.push(new_entry.clone());
                         }
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -504,7 +504,7 @@ fn setup_skills(force: bool) -> Result<()> {
                 continue;
             }
             println!(
-                "  Skipped (local edits detected): /{}  ({})",
+                "  Skipped (file differs from bundled version): /{}  ({})",
                 name,
                 path.display()
             );
@@ -528,7 +528,10 @@ fn setup_skills(force: bool) -> Result<()> {
             if existing == *content {
                 println!("  Up to date:      {}", path.display());
             } else {
-                println!("  Skipped (local edits detected): {}", path.display());
+                println!(
+                    "  Skipped (file differs from bundled version): {}",
+                    path.display()
+                );
                 println!("    Use --force to overwrite");
             }
             continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,8 @@ enum Commands {
         /// Source folder containing the backup
         folder: String,
     },
+    /// Install Claude Code skills and hooks into the current project
+    SetupSkills,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -395,6 +397,175 @@ fn restore_credentials(folder: &str) -> Result<()> {
     Ok(())
 }
 
+// --- Embedded Claude Code skills and hooks ---
+
+static SKILLS: &[(&str, &str)] = &[
+    (
+        "check-inbox",
+        include_str!("../claude/skills/check-inbox/SKILL.md"),
+    ),
+    ("compose", include_str!("../claude/skills/compose/SKILL.md")),
+    (
+        "email-search",
+        include_str!("../claude/skills/email-search/SKILL.md"),
+    ),
+    (
+        "email-reply",
+        include_str!("../claude/skills/email-reply/SKILL.md"),
+    ),
+    (
+        "email-digest",
+        include_str!("../claude/skills/email-digest/SKILL.md"),
+    ),
+    (
+        "email-forward",
+        include_str!("../claude/skills/email-forward/SKILL.md"),
+    ),
+    (
+        "setup-inboxapi",
+        include_str!("../claude/skills/setup-inboxapi/SKILL.md"),
+    ),
+];
+
+static HOOKS: &[(&str, &str)] = &[
+    (
+        "email-send-guard.js",
+        include_str!("../claude/hooks/email-send-guard.js"),
+    ),
+    (
+        "email-activity-logger.js",
+        include_str!("../claude/hooks/email-activity-logger.js"),
+    ),
+    (
+        "credential-check.js",
+        include_str!("../claude/hooks/credential-check.js"),
+    ),
+];
+
+static HOOKS_SETTINGS: &str = r#"{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__inboxapi__send_email|mcp__inboxapi__send_reply|mcp__inboxapi__forward_email",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/email-send-guard.js",
+            "statusMessage": "Reviewing outbound email..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "mcp__inboxapi__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/email-activity-logger.js"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/credential-check.js",
+            "statusMessage": "Checking InboxAPI credentials..."
+          }
+        ]
+      }
+    ]
+  }
+}"#;
+
+fn setup_skills() -> Result<()> {
+    let base = PathBuf::from(".claude");
+
+    // Write skills
+    for (name, content) in SKILLS {
+        let dir = base.join("skills").join(name);
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("Failed to create directory {}", dir.display()))?;
+        let path = dir.join("SKILL.md");
+        std::fs::write(&path, content)
+            .with_context(|| format!("Failed to write {}", path.display()))?;
+        println!("  Installed skill: /{}  ({})", name, path.display());
+    }
+
+    // Write hooks
+    let hooks_dir = base.join("hooks");
+    std::fs::create_dir_all(&hooks_dir)
+        .with_context(|| format!("Failed to create directory {}", hooks_dir.display()))?;
+    for (name, content) in HOOKS {
+        let path = hooks_dir.join(name);
+        std::fs::write(&path, content)
+            .with_context(|| format!("Failed to write {}", path.display()))?;
+        println!("  Installed hook:  {}", path.display());
+    }
+
+    // Merge hook settings into .claude/settings.json
+    let settings_path = base.join("settings.json");
+    let merged = merge_hook_settings(&settings_path)?;
+    std::fs::write(&settings_path, merged)
+        .with_context(|| format!("Failed to write {}", settings_path.display()))?;
+    println!("  Updated:         {}", settings_path.display());
+
+    println!();
+    println!("InboxAPI Claude Code skills and hooks installed successfully.");
+    println!("Available skills: /check-inbox, /compose, /email-search, /email-reply, /email-digest, /email-forward, /setup-inboxapi");
+    Ok(())
+}
+
+fn merge_hook_settings(settings_path: &PathBuf) -> Result<String> {
+    let new_settings: Value =
+        serde_json::from_str(HOOKS_SETTINGS).context("Failed to parse embedded hook settings")?;
+
+    let mut existing: Value = if settings_path.exists() {
+        let content = std::fs::read_to_string(settings_path)
+            .with_context(|| format!("Failed to read {}", settings_path.display()))?;
+        serde_json::from_str(&content).unwrap_or_else(|_| json!({}))
+    } else {
+        json!({})
+    };
+
+    // Merge hooks: for each event type, append our hook entries if not already present
+    if let Some(new_hooks) = new_settings.get("hooks").and_then(|h| h.as_object()) {
+        let existing_hooks = existing
+            .as_object_mut()
+            .unwrap()
+            .entry("hooks")
+            .or_insert_with(|| json!({}));
+        if let Some(existing_hooks_obj) = existing_hooks.as_object_mut() {
+            for (event, new_entries) in new_hooks {
+                let existing_entries = existing_hooks_obj.entry(event).or_insert_with(|| json!([]));
+                if let (Some(existing_arr), Some(new_arr)) =
+                    (existing_entries.as_array_mut(), new_entries.as_array())
+                {
+                    for new_entry in new_arr {
+                        // Check if an entry with the same matcher already exists
+                        let matcher = new_entry
+                            .get("matcher")
+                            .and_then(|m| m.as_str())
+                            .unwrap_or("");
+                        let already_exists = existing_arr.iter().any(|e| {
+                            e.get("matcher").and_then(|m| m.as_str()).unwrap_or("") == matcher
+                        });
+                        if !already_exists {
+                            existing_arr.push(new_entry.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    serde_json::to_string_pretty(&existing).context("Failed to serialize settings")
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -414,6 +585,7 @@ async fn main() -> Result<()> {
         Some(Commands::Reset) => reset_credentials(),
         Some(Commands::Backup { folder }) => backup_credentials(&folder),
         Some(Commands::Restore { folder }) => restore_credentials(&folder),
+        Some(Commands::SetupSkills) => setup_skills(),
         None => {
             // Prefer the endpoint stored in credentials, if available; fall back to CLI default.
             let endpoint = match load_credentials() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -510,12 +510,22 @@ fn setup_skills() -> Result<()> {
         println!("  Installed skill: /{}  ({})", name, path.display());
     }
 
-    // Write hooks
+    // Write hooks (skip if on-disk content already matches)
     let hooks_dir = base.join("hooks");
     std::fs::create_dir_all(&hooks_dir)
         .with_context(|| format!("Failed to create directory {}", hooks_dir.display()))?;
     for (name, content) in HOOKS {
         let path = hooks_dir.join(name);
+        if path.exists() {
+            let existing = std::fs::read_to_string(&path)
+                .with_context(|| format!("Failed to read existing {}", path.display()))?;
+            if existing == *content {
+                println!("  Up to date:      {}", path.display());
+            } else {
+                println!("  Skipped (local edits detected): {}", path.display());
+            }
+            continue;
+        }
         std::fs::write(&path, content)
             .with_context(|| format!("Failed to write {}", path.display()))?;
         println!("  Installed hook:  {}", path.display());
@@ -566,6 +576,12 @@ fn merge_hook_settings(settings_path: &PathBuf) -> Result<String> {
             .unwrap()
             .entry("hooks")
             .or_insert_with(|| json!({}));
+        if !existing_hooks.is_object() {
+            anyhow::bail!(
+                "{} has a 'hooks' key that is not a JSON object — cannot merge hook settings",
+                settings_path.display()
+            );
+        }
         if let Some(existing_hooks_obj) = existing_hooks.as_object_mut() {
             for (event, new_entries) in new_hooks {
                 let existing_entries = existing_hooks_obj.entry(event).or_insert_with(|| json!([]));
@@ -597,6 +613,11 @@ fn merge_hook_settings(settings_path: &PathBuf) -> Result<String> {
                                     .as_object_mut()
                                     .map(|obj| obj.entry("hooks").or_insert_with(|| json!([])));
                                 if let Some(entry_hooks_val) = entry_hooks {
+                                    // Coerce non-array hooks into an array
+                                    if !entry_hooks_val.is_array() {
+                                        let old_value = entry_hooks_val.clone();
+                                        *entry_hooks_val = json!([old_value]);
+                                    }
                                     if let Some(entry_hooks_arr) = entry_hooks_val.as_array_mut() {
                                         for new_hook in new_hooks_arr {
                                             let new_cmd = new_hook
@@ -3092,5 +3113,84 @@ mod tests {
     fn drain_sse_remainder_filters_non_message_events() {
         let buf = "event: ping\ndata: {}";
         assert!(drain_sse_remainder(buf).is_none());
+    }
+
+    // --- merge_hook_settings tests ---
+
+    fn temp_settings_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("inboxapi_test_{name}_{}.json", std::process::id()))
+    }
+
+    #[test]
+    fn merge_hook_settings_creates_settings_when_missing() {
+        let p = temp_settings_path("create");
+        let _ = std::fs::remove_file(&p);
+        let result = merge_hook_settings(&p).unwrap();
+        let _ = std::fs::remove_file(&p);
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed.get("hooks").is_some());
+    }
+
+    #[test]
+    fn merge_hook_settings_preserves_existing_keys() {
+        let p = temp_settings_path("preserve");
+        std::fs::write(&p, r#"{"customKey": "value"}"#).unwrap();
+        let result = merge_hook_settings(&p).unwrap();
+        let _ = std::fs::remove_file(&p);
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["customKey"], "value");
+        assert!(parsed.get("hooks").is_some());
+    }
+
+    #[test]
+    fn merge_hook_settings_does_not_duplicate_hooks() {
+        let p = temp_settings_path("nodupe");
+        let _ = std::fs::remove_file(&p);
+        let first = merge_hook_settings(&p).unwrap();
+        std::fs::write(&p, &first).unwrap();
+        let second = merge_hook_settings(&p).unwrap();
+        let _ = std::fs::remove_file(&p);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn merge_hook_settings_errors_on_invalid_json() {
+        let p = temp_settings_path("invalid");
+        std::fs::write(&p, "not valid json").unwrap();
+        let result = merge_hook_settings(&p);
+        let _ = std::fs::remove_file(&p);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn merge_hook_settings_errors_on_non_object_root() {
+        let p = temp_settings_path("nonobj");
+        std::fs::write(&p, "[1, 2, 3]").unwrap();
+        let result = merge_hook_settings(&p);
+        let _ = std::fs::remove_file(&p);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn merge_hook_settings_errors_on_non_object_hooks() {
+        let p = temp_settings_path("nonobjhooks");
+        std::fs::write(&p, r#"{"hooks": "not an object"}"#).unwrap();
+        let result = merge_hook_settings(&p);
+        let _ = std::fs::remove_file(&p);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn merge_hook_settings_coerces_non_array_event_entries() {
+        let p = temp_settings_path("coerce");
+        std::fs::write(
+            &p,
+            r#"{"hooks": {"PreToolUse": {"matcher": "old", "hooks": []}}}"#,
+        )
+        .unwrap();
+        let result = merge_hook_settings(&p).unwrap();
+        let _ = std::fs::remove_file(&p);
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed["hooks"]["PreToolUse"].is_array());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use reqwest::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::cmp::Ordering;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::io::{stdin, stdout, AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 #[derive(Parser)]
@@ -544,7 +544,7 @@ fn setup_skills() -> Result<()> {
     Ok(())
 }
 
-fn merge_hook_settings(settings_path: &PathBuf) -> Result<String> {
+fn merge_hook_settings(settings_path: &Path) -> Result<String> {
     let new_settings: Value =
         serde_json::from_str(HOOKS_SETTINGS).context("Failed to parse embedded hook settings")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,11 @@ enum Commands {
         folder: String,
     },
     /// Install Claude Code skills and hooks into the current project
-    SetupSkills,
+    SetupSkills {
+        /// Overwrite existing skill and hook files even if they have local edits
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -482,16 +486,16 @@ static HOOKS_SETTINGS: &str = r#"{
   }
 }"#;
 
-fn setup_skills() -> Result<()> {
+fn setup_skills(force: bool) -> Result<()> {
     let base = PathBuf::from(".claude");
 
-    // Write skills (skip if on-disk content already matches)
+    // Write skills (skip if on-disk content already matches, unless --force)
     for (name, content) in SKILLS {
         let dir = base.join("skills").join(name);
         std::fs::create_dir_all(&dir)
             .with_context(|| format!("Failed to create directory {}", dir.display()))?;
         let path = dir.join("SKILL.md");
-        if path.exists() {
+        if path.exists() && !force {
             let existing = std::fs::read_to_string(&path)
                 .with_context(|| format!("Failed to read existing {}", path.display()))?;
             if existing == *content {
@@ -503,6 +507,7 @@ fn setup_skills() -> Result<()> {
                 name,
                 path.display()
             );
+            println!("    Use --force to overwrite");
             continue;
         }
         std::fs::write(&path, content)
@@ -510,19 +515,20 @@ fn setup_skills() -> Result<()> {
         println!("  Installed skill: /{}  ({})", name, path.display());
     }
 
-    // Write hooks (skip if on-disk content already matches)
+    // Write hooks (skip if on-disk content already matches, unless --force)
     let hooks_dir = base.join("hooks");
     std::fs::create_dir_all(&hooks_dir)
         .with_context(|| format!("Failed to create directory {}", hooks_dir.display()))?;
     for (name, content) in HOOKS {
         let path = hooks_dir.join(name);
-        if path.exists() {
+        if path.exists() && !force {
             let existing = std::fs::read_to_string(&path)
                 .with_context(|| format!("Failed to read existing {}", path.display()))?;
             if existing == *content {
                 println!("  Up to date:      {}", path.display());
             } else {
                 println!("  Skipped (local edits detected): {}", path.display());
+                println!("    Use --force to overwrite");
             }
             continue;
         }
@@ -668,7 +674,7 @@ async fn main() -> Result<()> {
         Some(Commands::Reset) => reset_credentials(),
         Some(Commands::Backup { folder }) => backup_credentials(&folder),
         Some(Commands::Restore { folder }) => restore_credentials(&folder),
-        Some(Commands::SetupSkills) => setup_skills(),
+        Some(Commands::SetupSkills { force }) => setup_skills(force),
         None => {
             // Prefer the endpoint stored in credentials, if available; fall back to CLI default.
             let endpoint = match load_credentials() {


### PR DESCRIPTION
## Summary

- Bundle 7 skills (`/check-inbox`, `/compose`, `/email-search`, `/email-reply`, `/email-digest`, `/email-forward`, `/setup-inboxapi`) and 3 hooks (email send guard, activity logger, credential check) into the npm package
- Add `inboxapi setup-skills` CLI command that installs skills and hooks into the project's `.claude/` directory with merged `settings.json` config
- Skills provide guided workflows for common InboxAPI email operations via Claude Code

## Test plan

- [x] `cargo fmt` — no formatting issues
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — all 94 tests pass
- [x] `cargo build` — clean compilation
- [ ] Manual test: `npx -y @inboxapi/cli setup-skills` installs skills/hooks correctly