### PR TITLE
📝 docs: add get_announcements to tools table

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -35,6 +35,7 @@ Authentication is handled automatically by the CLI proxy. You do not need to cre
 | `get_thread` | Get all emails in a thread |
 | `auth_introspect` | Check current token status |
 | `get_addressbook` | View your addressbook (auto-populated when you send email) |
+| `get_announcements` | Check for system news, tips, and community challenges |
 | `whoami` | Get your account name, email address, and endpoint |
 
 ---


### PR DESCRIPTION
## Summary
- Added `get_announcements` tool to the Available Tools table in `docs/help.md`
- Describes the tool as checking for system news, tips, and community challenges

## Test plan
- [ ] Verify the help.md renders correctly with the new table row
- [ ] Confirm the tool description is accurate