### PR TITLE
feat: add CLI subcommands for direct email operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,19 @@ cargo run -- whoami  # Show current account info
 cargo run -- reset   # Delete stored credentials
 cargo run -- backup <folder>   # Back up credentials
 cargo run -- restore <folder>  # Restore credentials from backup
+
+# CLI subcommands (preferred for agents with shell access)
+cargo run -- send-email --to user@example.com --subject "Hi" --body "Hello"
+cargo run -- send-email --to user@example.com --subject "Report" --body "Attached" --attachment ./report.pdf
+cargo run -- send-email --to user@example.com --subject "Fwd" --body "See attached" --attachment-ref UUID
+cargo run -- get-emails --limit 5
+cargo run -- get-emails --limit 5 --human
+cargo run -- get-email "<message-id>"
+cargo run -- search-emails --query "invoice"
+cargo run -- get-attachment abc123 --output ./file.pdf
+cargo run -- send-reply --message-id "<id>" --body "Thanks!"
+cargo run -- forward-email --message-id "<id>" --to recipient@example.com
+cargo run -- help
 ```
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,14 @@ Rust-based STDIO proxy that bridges JSON-RPC (MCP protocol) over STDIO to the re
 - `cargo run -- reset` — delete stored credentials (with optional backup prompt)
 - `cargo run -- backup <folder>` — back up credentials to a folder
 - `cargo run -- restore <folder>` — restore credentials from a backup folder
+- `cargo run -- send-email --to user@example.com --subject "Hi" --body "Hello"` — send an email
+- `cargo run -- get-emails --limit 5` — list inbox emails
+- `cargo run -- get-email "<message-id>"` — get a single email
+- `cargo run -- search-emails --query "keyword"` — search emails
+- `cargo run -- get-attachment <id> --output ./file.pdf` — download an attachment
+- `cargo run -- send-reply --message-id "<id>" --body "Reply"` — reply to an email
+- `cargo run -- forward-email --message-id "<id>" --to user@example.com` — forward an email
+- `cargo run -- help` — show CLI help with examples
 
 ## Architecture
 - **Single-file proxy** (`src/main.rs`): reads JSON-RPC from stdin, POSTs to remote endpoint, streams SSE responses to stdout. Injects stored access tokens into `tools/call` arguments.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,7 +627,9 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "data-encoding",
  "dirs",
+ "mime_guess",
  "rand 0.8.5",
  "reqwest",
  "serde",
@@ -717,6 +725,22 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -1442,6 +1466,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ tokio = { version = "1.0", features = ["full"] }
 sha1 = "0.10"
 chrono = "0.4"
 rand = "0.8"
+data-encoding = "2.6"
+mime_guess = "2.0"
 
 [profile.release]
 strip = true

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -18,6 +18,16 @@ cargo fmt            # Format code
 cargo run -- proxy   # Start STDIO proxy (default)
 cargo run -- login   # Authenticate and store credentials
 cargo run -- whoami  # Show current account
+
+# CLI subcommands
+cargo run -- send-email --to user@example.com --subject "Hi" --body "Hello"
+cargo run -- get-emails --limit 5
+cargo run -- get-email "<message-id>"
+cargo run -- search-emails --query "keyword"
+cargo run -- get-attachment <id> --output ./file.pdf
+cargo run -- send-reply --message-id "<id>" --body "Reply"
+cargo run -- forward-email --message-id "<id>" --to user@example.com
+cargo run -- help
 ```
 
 ## Development Workflow

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Give your AI agent its own personal email address. Send, receive, read, search, 
 - [Installation](#installation)
 - [Getting Started](#getting-started)
 - [Commands](#commands)
+- [CLI Commands](#cli-commands)
 - [Usage with MCP Clients](#usage-with-mcp-clients)
 - [Skills for Claude Code](#skills-for-claude-code)
 - [Development](#development)
@@ -45,6 +46,7 @@ The CLI acts as a local bridge between your AI client and the [InboxAPI](https:/
 - **This is your agent's personal email** — InboxAPI gives your AI agent its own email address for personal use. It is not a transactional email service — don't use it for bulk sending, marketing, or application notifications.
 - **Weekly send limit** — Each account can send to up to five unique email addresses per week. This resets weekly.
 - **Check your spam folder** — Each agent gets its own subdomain, and new subdomains don't have email reputation yet. Early messages may land in your recipient's spam or junk folder. Adding your agent's email address to your contacts or allowlist helps. Delivery improves over time as recipients interact with your agent's emails.
+- **Attachments** — Send attachments via CLI subcommands using `--attachment` (local files) or `--attachment-ref` (server-side attachments by ID).
 - **No rich text yet** — Emails are sent as plain text only. Rich text (HTML) support is coming soon.
 - **Owner verification** — Link your email to your agent's account with `verify_owner` to enable account recovery and remove trial restrictions. Recommended as a first step after setup.
 
@@ -152,9 +154,70 @@ inboxapi setup-skills
 inboxapi setup-skills --force  # Overwrite existing skills and hooks
 ```
 
+## CLI Commands
+
+For agents with shell access, CLI subcommands are the simplest way to use InboxAPI — no MCP, JSON-RPC, or base64 knowledge needed.
+
+### `send-email`
+
+```bash
+inboxapi send-email --to user@example.com --subject "Hello" --body "Hi there"
+inboxapi send-email --to user@example.com --subject "Report" --body "See attached" --attachment ./report.pdf
+inboxapi send-email --to user@example.com --subject "Fwd" --body "See attached" --attachment-ref 9f0206bb-...
+inboxapi send-email --to "a@b.com, c@d.com" --subject "Hi" --body "Hello" --cc "cc@b.com" --priority high
+```
+
+Supports `--cc`, `--bcc`, `--html-body`, `--from-name`, `--priority`, `--attachment` (local files, repeatable), and `--attachment-ref` (server-side attachment IDs, repeatable).
+
+### `get-emails`
+
+```bash
+inboxapi get-emails --limit 5
+inboxapi get-emails --limit 5 --human
+```
+
+### `get-email`
+
+```bash
+inboxapi get-email "<message-id>"
+```
+
+### `search-emails`
+
+```bash
+inboxapi search-emails --query "invoice" --limit 10
+```
+
+### `get-attachment`
+
+```bash
+inboxapi get-attachment abc123                      # prints signed URL as JSON
+inboxapi get-attachment abc123 --output ./file.pdf  # downloads to file
+```
+
+### `send-reply`
+
+```bash
+inboxapi send-reply --message-id "<msg-id>" --body "Thanks!"
+```
+
+### `forward-email`
+
+```bash
+inboxapi forward-email --message-id "<msg-id>" --to recipient@example.com --note "FYI"
+```
+
+### `help`
+
+```bash
+inboxapi help  # CLI-focused help with examples
+```
+
+All CLI commands support the `--human` flag for human-readable output instead of JSON.
+
 ## Usage with MCP Clients
 
-InboxAPI CLI works as an MCP STDIO transport. Point your MCP client at the `inboxapi` binary:
+InboxAPI CLI also works as an MCP STDIO transport. Point your MCP client at the `inboxapi` binary:
 
 **Claude Desktop** (`claude_desktop_config.json`):
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -12,6 +12,21 @@ Email tools for AI agents via MCP.
 
 ---
 
+## CLI Subcommands
+
+Agents with shell access can also use CLI subcommands directly — no MCP or JSON-RPC knowledge needed:
+
+```
+inboxapi send-email --to user@example.com --subject "Hello" --body "Hi there"
+inboxapi get-emails --limit 5 --human
+inboxapi search-emails --query "invoice"
+inboxapi help
+```
+
+Run `inboxapi help` for the full list of CLI commands and examples.
+
+---
+
 ## Authentication
 
 Authentication is handled automatically by the CLI proxy. You do not need to create accounts, manage tokens, or store credentials. Simply call the email tools below directly. Do not search for credential files or call `account_create`, `auth_exchange`, or `auth_refresh`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1028,6 +1028,9 @@ fn build_attachment_from_file(path: &str) -> Result<Value> {
     }))
 }
 
+/// Timeout for downloading attachments (used in both resolve_attachment_ref and get-attachment).
+const ATTACHMENT_DOWNLOAD_TIMEOUT_SECS: u64 = 120;
+
 /// Resolve a server-side attachment ref to an attachment entry.
 async fn resolve_attachment_ref(
     attachment_id: &str,
@@ -1063,7 +1066,9 @@ async fn resolve_attachment_ref(
     // Download the file
     let file_resp = http_client
         .get(url)
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(
+            ATTACHMENT_DOWNLOAD_TIMEOUT_SECS,
+        ))
         .send()
         .await
         .context("Failed to download attachment")?;
@@ -1394,7 +1399,9 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
                     .ok_or_else(|| anyhow!("No URL in get_attachment response"))?;
                 let file_resp = http_client
                     .get(url)
-                    .timeout(std::time::Duration::from_secs(30))
+                    .timeout(std::time::Duration::from_secs(
+                        ATTACHMENT_DOWNLOAD_TIMEOUT_SECS,
+                    ))
                     .send()
                     .await
                     .context("Failed to download attachment")?;
@@ -1436,7 +1443,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
         }) => {
             let mut args = json!({
                 "message_id": message_id,
-                "to": [to],
+                "to": split_csv(to),
             });
             if let Some(note) = note {
                 args["note"] = json!(note);

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,10 @@ struct Cli {
 
     #[arg(long, default_value = "https://mcp.inboxapi.ai/mcp")]
     endpoint: String,
+
+    /// Output human-readable text instead of JSON
+    #[arg(long, global = true)]
+    human: bool,
 }
 
 #[derive(Subcommand)]
@@ -57,6 +61,93 @@ enum Commands {
         #[arg(long)]
         force: bool,
     },
+    /// Send an email
+    SendEmail {
+        /// Recipient email address(es), comma-separated
+        #[arg(long)]
+        to: String,
+        /// Email subject
+        #[arg(long)]
+        subject: String,
+        /// Email body (plain text)
+        #[arg(long)]
+        body: String,
+        /// CC recipients, comma-separated
+        #[arg(long)]
+        cc: Option<String>,
+        /// BCC recipients, comma-separated
+        #[arg(long)]
+        bcc: Option<String>,
+        /// HTML body
+        #[arg(long)]
+        html_body: Option<String>,
+        /// Sender display name
+        #[arg(long)]
+        from_name: Option<String>,
+        /// Priority: low, normal, or high
+        #[arg(long)]
+        priority: Option<String>,
+        /// Attach a local file (can be repeated)
+        #[arg(long = "attachment")]
+        attachments: Vec<String>,
+        /// Attach a server-side attachment by ID (can be repeated)
+        #[arg(long = "attachment-ref")]
+        attachment_refs: Vec<String>,
+    },
+    /// List inbox emails
+    GetEmails {
+        /// Maximum number of emails to return
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Offset for pagination
+        #[arg(long)]
+        offset: Option<u32>,
+    },
+    /// Get a single email by message ID
+    GetEmail {
+        /// The message ID to retrieve
+        message_id: String,
+    },
+    /// Search emails
+    SearchEmails {
+        /// Search query
+        #[arg(long)]
+        query: String,
+        /// Maximum number of results
+        #[arg(long)]
+        limit: Option<u32>,
+    },
+    /// Get or download an attachment
+    GetAttachment {
+        /// The attachment ID
+        attachment_id: String,
+        /// Save the attachment to this path
+        #[arg(long)]
+        output: Option<String>,
+    },
+    /// Reply to an email
+    SendReply {
+        /// The message ID to reply to
+        #[arg(long)]
+        message_id: String,
+        /// Reply body (plain text)
+        #[arg(long)]
+        body: String,
+    },
+    /// Forward an email
+    ForwardEmail {
+        /// The message ID to forward
+        #[arg(long)]
+        message_id: String,
+        /// Forward to this email address
+        #[arg(long)]
+        to: String,
+        /// Optional note to include
+        #[arg(long)]
+        note: Option<String>,
+    },
+    /// Show CLI help with examples
+    Help,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -687,6 +778,14 @@ async fn main() -> Result<()> {
         Some(Commands::Backup { folder }) => backup_credentials(&folder),
         Some(Commands::Restore { folder }) => restore_credentials(&folder),
         Some(Commands::SetupSkills { force }) => setup_skills(force),
+        Some(Commands::SendEmail { .. })
+        | Some(Commands::GetEmails { .. })
+        | Some(Commands::GetEmail { .. })
+        | Some(Commands::SearchEmails { .. })
+        | Some(Commands::GetAttachment { .. })
+        | Some(Commands::SendReply { .. })
+        | Some(Commands::ForwardEmail { .. })
+        | Some(Commands::Help) => run_cli_command(&cli).await,
         None => {
             // Prefer the endpoint stored in credentials, if available; fall back to CLI default.
             let endpoint = match load_credentials() {
@@ -765,6 +864,594 @@ fn drain_sse_remainder(buf: &str) -> Option<SseEvent> {
     } else {
         None
     }
+}
+
+/// Reusable helper: call an MCP tool via JSON-RPC over HTTP.
+/// Loads credentials, builds the request, injects token, handles token refresh.
+async fn call_mcp_tool(
+    endpoint: &str,
+    creds: &mut Option<Credentials>,
+    http_client: &HttpClient,
+    tool_name: &str,
+    arguments: Value,
+) -> Result<Value> {
+    let msg_id = 1;
+    let mut msg = json!({
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "method": "tools/call",
+        "params": {
+            "name": tool_name,
+            "arguments": arguments
+        }
+    });
+
+    // Inject token if we have credentials
+    if let Some(c) = creds.as_ref() {
+        inject_token(&mut msg, c);
+    }
+    strip_domain(&mut msg);
+
+    let resp = http_client
+        .post(endpoint)
+        .header(CONTENT_TYPE, "application/json")
+        .header(ACCEPT, "application/json, text/event-stream")
+        .json(&msg)
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let err_text = resp
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        return Err(anyhow!("HTTP error {}: {}", status, err_text));
+    }
+
+    let response = parse_response(resp).await?;
+
+    // Handle token expiry with automatic refresh
+    if is_token_expired_error(&response) {
+        if let Some(current_creds) = creds.clone() {
+            eprintln!("[inboxapi] Token expired. Attempting refresh...");
+            match reauth_with_fallback(&current_creds, endpoint, http_client).await {
+                Ok(new_creds) => {
+                    // Rebuild message with new token
+                    if let Some(args) = msg
+                        .get_mut("params")
+                        .and_then(|p| p.get_mut("arguments"))
+                        .and_then(|a| a.as_object_mut())
+                    {
+                        args.insert("token".to_string(), json!(new_creds.access_token.clone()));
+                        if let Some(ref secret) = new_creds.encryption_secret {
+                            args.insert("encryption_secret".to_string(), json!(secret.clone()));
+                        } else {
+                            args.remove("encryption_secret");
+                        }
+                    }
+                    *creds = Some(new_creds);
+
+                    // Retry once
+                    let retry_resp = http_client
+                        .post(endpoint)
+                        .header(CONTENT_TYPE, "application/json")
+                        .header(ACCEPT, "application/json, text/event-stream")
+                        .json(&msg)
+                        .send()
+                        .await?;
+
+                    if retry_resp.status().is_success() {
+                        return parse_response(retry_resp).await;
+                    }
+                }
+                Err(e) => {
+                    eprintln!("[inboxapi] Re-auth failed: {}", e);
+                }
+            }
+        }
+    }
+
+    Ok(response)
+}
+
+/// Extract the text content from a tool response.
+fn extract_tool_result_text(response: &Value) -> Result<String> {
+    // Check for tool-level errors
+    if response
+        .get("result")
+        .and_then(|r| r.get("isError"))
+        .and_then(|e| e.as_bool())
+        .unwrap_or(false)
+    {
+        let error_text = response
+            .get("result")
+            .and_then(|r| r.get("content"))
+            .and_then(|c| c.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|item| item.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap_or("Unknown error");
+        return Err(anyhow!("{}", error_text));
+    }
+
+    // Check for JSON-RPC error
+    if let Some(error) = response.get("error") {
+        let msg = error
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("Unknown error");
+        return Err(anyhow!("{}", msg));
+    }
+
+    response
+        .get("result")
+        .and_then(|r| r.get("content"))
+        .and_then(|c| c.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|item| item.get("text"))
+        .and_then(|t| t.as_str())
+        .map(String::from)
+        .ok_or_else(|| anyhow!("No text content in response"))
+}
+
+/// Split a comma-separated string into a Vec of trimmed strings.
+fn split_csv(s: &str) -> Vec<String> {
+    s.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Guess MIME content type from a file path extension.
+fn guess_content_type(path: &Path) -> String {
+    mime_guess::from_path(path)
+        .first_or_octet_stream()
+        .to_string()
+}
+
+/// Build an attachment entry from a local file path.
+fn build_attachment_from_file(path: &str) -> Result<Value> {
+    let p = Path::new(path);
+    let bytes =
+        std::fs::read(p).with_context(|| format!("Failed to read attachment file: {}", path))?;
+    let filename = p
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "attachment".to_string());
+    let content_type = guess_content_type(p);
+    let content = data_encoding::BASE64.encode(&bytes);
+    Ok(json!({
+        "filename": filename,
+        "content_type": content_type,
+        "content": content
+    }))
+}
+
+/// Resolve a server-side attachment ref to an attachment entry.
+async fn resolve_attachment_ref(
+    attachment_id: &str,
+    endpoint: &str,
+    creds: &mut Option<Credentials>,
+    http_client: &HttpClient,
+) -> Result<Value> {
+    // Call get_attachment to get the signed URL and metadata
+    let response = call_mcp_tool(
+        endpoint,
+        creds,
+        http_client,
+        "get_attachment",
+        json!({"attachment_id": attachment_id}),
+    )
+    .await?;
+    let text = extract_tool_result_text(&response)?;
+    let data: Value =
+        serde_json::from_str(&text).context("Failed to parse get_attachment response")?;
+
+    let url = data["url"]
+        .as_str()
+        .ok_or_else(|| anyhow!("No URL in get_attachment response"))?;
+    let filename = data["filename"]
+        .as_str()
+        .unwrap_or("attachment")
+        .to_string();
+    let content_type = data["content_type"]
+        .as_str()
+        .unwrap_or("application/octet-stream")
+        .to_string();
+
+    // Download the file
+    let file_resp = http_client
+        .get(url)
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await
+        .context("Failed to download attachment")?;
+    let bytes = file_resp
+        .bytes()
+        .await
+        .context("Failed to read attachment bytes")?;
+    let content = data_encoding::BASE64.encode(&bytes);
+
+    Ok(json!({
+        "filename": filename,
+        "content_type": content_type,
+        "content": content
+    }))
+}
+
+/// Build the arguments JSON for send_email from CLI args.
+#[allow(clippy::too_many_arguments)]
+fn build_send_email_args(
+    to: &str,
+    subject: &str,
+    body: &str,
+    cc: Option<&str>,
+    bcc: Option<&str>,
+    html_body: Option<&str>,
+    from_name: Option<&str>,
+    priority: Option<&str>,
+    attachments_json: Vec<Value>,
+) -> Value {
+    let mut args = json!({
+        "to": split_csv(to),
+        "subject": subject,
+        "body": body,
+    });
+    if let Some(cc) = cc {
+        args["cc"] = json!(split_csv(cc));
+    }
+    if let Some(bcc) = bcc {
+        args["bcc"] = json!(split_csv(bcc));
+    }
+    if let Some(html_body) = html_body {
+        args["html_body"] = json!(html_body);
+    }
+    if let Some(from_name) = from_name {
+        args["from_name"] = json!(from_name);
+    }
+    if let Some(priority) = priority {
+        args["priority"] = json!(priority);
+    }
+    if !attachments_json.is_empty() {
+        args["attachments"] = json!(attachments_json);
+    }
+    args
+}
+
+/// Format tool result for human-readable output.
+fn format_human_output(tool_name: &str, text: &str) -> String {
+    match tool_name {
+        "send_email" => {
+            if let Ok(data) = serde_json::from_str::<Value>(text) {
+                let msg_id = data["message_id"]
+                    .as_str()
+                    .or_else(|| data["messageId"].as_str())
+                    .unwrap_or("unknown");
+                format!("Email sent. Message ID: {}", msg_id)
+            } else {
+                format!("Email sent.\n{}", text)
+            }
+        }
+        "get_emails" => {
+            if let Ok(emails) = serde_json::from_str::<Vec<Value>>(text) {
+                if emails.is_empty() {
+                    return "No emails found.".to_string();
+                }
+                let mut lines = Vec::new();
+                for email in &emails {
+                    let from = email["from"]
+                        .as_str()
+                        .or_else(|| email["sender"].as_str())
+                        .unwrap_or("unknown");
+                    let subject = email["subject"].as_str().unwrap_or("(no subject)");
+                    let date = email["date"]
+                        .as_str()
+                        .or_else(|| email["received_at"].as_str())
+                        .unwrap_or("");
+                    lines.push(format!(
+                        "  From: {}  Subject: {}  Date: {}",
+                        from, subject, date
+                    ));
+                }
+                format!("{} email(s):\n{}", emails.len(), lines.join("\n"))
+            } else {
+                text.to_string()
+            }
+        }
+        "get_email" => {
+            if let Ok(email) = serde_json::from_str::<Value>(text) {
+                let from = email["from"]
+                    .as_str()
+                    .or_else(|| email["sender"].as_str())
+                    .unwrap_or("unknown");
+                let to = email["to"].as_str().unwrap_or("");
+                let subject = email["subject"].as_str().unwrap_or("(no subject)");
+                let date = email["date"]
+                    .as_str()
+                    .or_else(|| email["received_at"].as_str())
+                    .unwrap_or("");
+                let body = email["body"]
+                    .as_str()
+                    .or_else(|| email["text_body"].as_str())
+                    .unwrap_or("");
+                format!(
+                    "From: {}\nTo: {}\nDate: {}\nSubject: {}\n\n{}",
+                    from, to, date, subject, body
+                )
+            } else {
+                text.to_string()
+            }
+        }
+        "search_emails" => {
+            if let Ok(results) = serde_json::from_str::<Vec<Value>>(text) {
+                if results.is_empty() {
+                    return "No results found.".to_string();
+                }
+                let mut lines = Vec::new();
+                for email in &results {
+                    let from = email["from"]
+                        .as_str()
+                        .or_else(|| email["sender"].as_str())
+                        .unwrap_or("unknown");
+                    let subject = email["subject"].as_str().unwrap_or("(no subject)");
+                    lines.push(format!("  From: {}  Subject: {}", from, subject));
+                }
+                format!("{} result(s):\n{}", results.len(), lines.join("\n"))
+            } else {
+                text.to_string()
+            }
+        }
+        "send_reply" => {
+            if let Ok(data) = serde_json::from_str::<Value>(text) {
+                let msg_id = data["message_id"]
+                    .as_str()
+                    .or_else(|| data["messageId"].as_str())
+                    .unwrap_or("unknown");
+                format!("Reply sent. Message ID: {}", msg_id)
+            } else {
+                format!("Reply sent.\n{}", text)
+            }
+        }
+        "forward_email" => {
+            if let Ok(data) = serde_json::from_str::<Value>(text) {
+                let msg_id = data["message_id"]
+                    .as_str()
+                    .or_else(|| data["messageId"].as_str())
+                    .unwrap_or("unknown");
+                format!("Email forwarded. Message ID: {}", msg_id)
+            } else {
+                format!("Email forwarded.\n{}", text)
+            }
+        }
+        _ => text.to_string(),
+    }
+}
+
+/// Print tool result to stdout, respecting --human flag.
+fn print_result(tool_name: &str, text: &str, human: bool) {
+    if human {
+        println!("{}", format_human_output(tool_name, text));
+    } else {
+        println!("{}", text);
+    }
+}
+
+const CLI_HELP_TEXT: &str = "\
+inboxapi — Email for your AI
+
+Commands:
+  send-email     Send an email (supports --attachment and --attachment-ref)
+  get-emails     List inbox emails
+  get-email      Get a single email by message ID
+  search-emails  Search your inbox
+  get-attachment  Get or download an attachment
+  send-reply     Reply to an email
+  forward-email  Forward an email
+  whoami         Show current account info
+  proxy          Start MCP STDIO proxy (default)
+  login          Create account and store credentials
+  help           Show this help
+
+Global flags:
+  --human        Output human-readable text instead of JSON
+  --endpoint     Override the MCP endpoint URL
+
+Examples:
+  inboxapi send-email --to user@example.com --subject \"Hello\" --body \"Hi there\"
+  inboxapi send-email --to user@example.com --subject \"Invoice\" --body \"Attached\" --attachment ./invoice.pdf
+  inboxapi send-email --to user@example.com --subject \"Fwd\" --body \"See attached\" --attachment-ref 9f0206bb-...
+  inboxapi get-emails --limit 5
+  inboxapi get-emails --limit 5 --human
+  inboxapi search-emails --query \"invoice\"
+  inboxapi get-attachment abc123 --output ./file.pdf
+  inboxapi send-reply --message-id \"<msg-id>\" --body \"Thanks!\"
+  inboxapi forward-email --message-id \"<msg-id>\" --to recipient@example.com
+";
+
+/// Run a CLI subcommand that calls an MCP tool.
+async fn run_cli_command(cli: &Cli) -> Result<()> {
+    let http_client = HttpClient::new();
+
+    // Load credentials, auto-creating account if missing
+    let mut creds: Option<Credentials> = match load_credentials() {
+        Ok(c) => Some(c),
+        Err(_) => {
+            let name = generate_agent_name();
+            eprintln!(
+                "[inboxapi] No credentials found. Auto-creating account '{}'...",
+                name
+            );
+            let endpoint = cli.endpoint.as_str();
+            match create_account_and_authenticate(&name, endpoint, &http_client).await {
+                Ok(c) => {
+                    eprintln!("[inboxapi] Account created successfully.");
+                    Some(c)
+                }
+                Err(e) => {
+                    eprintln!("[inboxapi] Auto-login failed: {}. Cannot proceed.", e);
+                    return Err(anyhow!("Not authenticated. Run 'inboxapi login' first."));
+                }
+            }
+        }
+    };
+
+    let endpoint = creds
+        .as_ref()
+        .map(|c| c.endpoint.clone())
+        .unwrap_or_else(|| cli.endpoint.clone());
+
+    match cli.command {
+        Some(Commands::SendEmail {
+            ref to,
+            ref subject,
+            ref body,
+            ref cc,
+            ref bcc,
+            ref html_body,
+            ref from_name,
+            ref priority,
+            ref attachments,
+            ref attachment_refs,
+        }) => {
+            let mut attachment_entries: Vec<Value> = Vec::new();
+
+            // Process local file attachments
+            for path in attachments {
+                let entry = build_attachment_from_file(path)?;
+                attachment_entries.push(entry);
+            }
+
+            // Process server-side attachment refs
+            for ref_id in attachment_refs {
+                let entry =
+                    resolve_attachment_ref(ref_id, &endpoint, &mut creds, &http_client).await?;
+                attachment_entries.push(entry);
+            }
+
+            let args = build_send_email_args(
+                to,
+                subject,
+                body,
+                cc.as_deref(),
+                bcc.as_deref(),
+                html_body.as_deref(),
+                from_name.as_deref(),
+                priority.as_deref(),
+                attachment_entries,
+            );
+
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "send_email", args).await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("send_email", &text, cli.human);
+        }
+        Some(Commands::GetEmails { limit, offset }) => {
+            let mut args = json!({});
+            if let Some(limit) = limit {
+                args["limit"] = json!(limit);
+            }
+            if let Some(offset) = offset {
+                args["offset"] = json!(offset);
+            }
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "get_emails", args).await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("get_emails", &text, cli.human);
+        }
+        Some(Commands::GetEmail { ref message_id }) => {
+            let args = json!({"message_id": message_id});
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "get_email", args).await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("get_email", &text, cli.human);
+        }
+        Some(Commands::SearchEmails { ref query, limit }) => {
+            let mut args = json!({"query": query});
+            if let Some(limit) = limit {
+                args["limit"] = json!(limit);
+            }
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "search_emails", args).await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("search_emails", &text, cli.human);
+        }
+        Some(Commands::GetAttachment {
+            ref attachment_id,
+            ref output,
+        }) => {
+            let args = json!({"attachment_id": attachment_id});
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "get_attachment", args).await?;
+            let text = extract_tool_result_text(&response)?;
+
+            if let Some(output_path) = output {
+                // Download the file and save it
+                let data: Value = serde_json::from_str(&text)
+                    .context("Failed to parse get_attachment response")?;
+                let url = data["url"]
+                    .as_str()
+                    .ok_or_else(|| anyhow!("No URL in get_attachment response"))?;
+                let file_resp = http_client
+                    .get(url)
+                    .timeout(std::time::Duration::from_secs(30))
+                    .send()
+                    .await
+                    .context("Failed to download attachment")?;
+                let bytes = file_resp
+                    .bytes()
+                    .await
+                    .context("Failed to read attachment bytes")?;
+                std::fs::write(output_path, &bytes)
+                    .with_context(|| format!("Failed to write to {}", output_path))?;
+                if cli.human {
+                    println!("Downloaded to {}", output_path);
+                } else {
+                    println!(
+                        "{}",
+                        json!({"downloaded_to": output_path, "size": bytes.len()})
+                    );
+                }
+            } else {
+                println!("{}", text);
+            }
+        }
+        Some(Commands::SendReply {
+            ref message_id,
+            ref body,
+        }) => {
+            let args = json!({
+                "in_reply_to": message_id,
+                "body": body,
+            });
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "send_reply", args).await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("send_reply", &text, cli.human);
+        }
+        Some(Commands::ForwardEmail {
+            ref message_id,
+            ref to,
+            ref note,
+        }) => {
+            let mut args = json!({
+                "message_id": message_id,
+                "to": [to],
+            });
+            if let Some(note) = note {
+                args["note"] = json!(note);
+            }
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "forward_email", args).await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("forward_email", &text, cli.human);
+        }
+        Some(Commands::Help) => {
+            print!("{}", CLI_HELP_TEXT);
+        }
+        _ => unreachable!("run_cli_command called with non-CLI subcommand"),
+    }
+    Ok(())
 }
 
 async fn run_proxy(endpoint: String) -> Result<()> {
@@ -4196,5 +4883,325 @@ mod tests {
         let ua = build_client_user_agent(&info);
         // Name truncated to 64 chars
         assert!(ua.len() < 150);
+    }
+
+    // --- CLI subcommand tests ---
+
+    // --- split_csv tests ---
+
+    #[test]
+    fn test_split_csv_basic() {
+        let result = split_csv("a@b.com, c@d.com, e@f.com");
+        assert_eq!(result, vec!["a@b.com", "c@d.com", "e@f.com"]);
+    }
+
+    #[test]
+    fn test_split_csv_single() {
+        let result = split_csv("a@b.com");
+        assert_eq!(result, vec!["a@b.com"]);
+    }
+
+    #[test]
+    fn test_split_csv_trims_whitespace() {
+        let result = split_csv("  a@b.com ,  c@d.com  ");
+        assert_eq!(result, vec!["a@b.com", "c@d.com"]);
+    }
+
+    #[test]
+    fn test_split_csv_filters_empty() {
+        let result = split_csv("a@b.com,,c@d.com,");
+        assert_eq!(result, vec!["a@b.com", "c@d.com"]);
+    }
+
+    // --- guess_content_type tests ---
+
+    #[test]
+    fn test_guess_content_type_pdf() {
+        assert_eq!(guess_content_type(Path::new("doc.pdf")), "application/pdf");
+    }
+
+    #[test]
+    fn test_guess_content_type_txt() {
+        assert_eq!(guess_content_type(Path::new("readme.txt")), "text/plain");
+    }
+
+    #[test]
+    fn test_guess_content_type_png() {
+        assert_eq!(guess_content_type(Path::new("image.png")), "image/png");
+    }
+
+    #[test]
+    fn test_guess_content_type_unknown() {
+        assert_eq!(
+            guess_content_type(Path::new("file.xyz123")),
+            "application/octet-stream"
+        );
+    }
+
+    // --- build_send_email_args tests ---
+
+    #[test]
+    fn test_send_email_args_basic() {
+        let args = build_send_email_args(
+            "a@b.com",
+            "Hello",
+            "Body text",
+            None,
+            None,
+            None,
+            None,
+            None,
+            vec![],
+        );
+        assert_eq!(args["to"], json!(["a@b.com"]));
+        assert_eq!(args["subject"], "Hello");
+        assert_eq!(args["body"], "Body text");
+        assert!(args.get("cc").is_none());
+        assert!(args.get("attachments").is_none());
+    }
+
+    #[test]
+    fn test_send_email_args_with_cc_bcc() {
+        let args = build_send_email_args(
+            "a@b.com",
+            "Hi",
+            "Body",
+            Some("cc1@b.com, cc2@b.com"),
+            Some("bcc@b.com"),
+            None,
+            None,
+            None,
+            vec![],
+        );
+        assert_eq!(args["cc"], json!(["cc1@b.com", "cc2@b.com"]));
+        assert_eq!(args["bcc"], json!(["bcc@b.com"]));
+    }
+
+    #[test]
+    fn test_send_email_args_with_all_options() {
+        let args = build_send_email_args(
+            "a@b.com",
+            "Hi",
+            "Body",
+            Some("cc@b.com"),
+            Some("bcc@b.com"),
+            Some("<p>Hello</p>"),
+            Some("sender-name"),
+            Some("high"),
+            vec![],
+        );
+        assert_eq!(args["html_body"], "<p>Hello</p>");
+        assert_eq!(args["from_name"], "sender-name");
+        assert_eq!(args["priority"], "high");
+    }
+
+    #[test]
+    fn test_send_email_args_with_attachments() {
+        let attachments = vec![json!({
+            "filename": "test.pdf",
+            "content_type": "application/pdf",
+            "content": "base64data"
+        })];
+        let args = build_send_email_args(
+            "a@b.com",
+            "Hi",
+            "Body",
+            None,
+            None,
+            None,
+            None,
+            None,
+            attachments,
+        );
+        let atts = args["attachments"].as_array().unwrap();
+        assert_eq!(atts.len(), 1);
+        assert_eq!(atts[0]["filename"], "test.pdf");
+    }
+
+    #[test]
+    fn test_send_email_args_multiple_recipients() {
+        let args = build_send_email_args(
+            "a@b.com, c@d.com",
+            "Hi",
+            "Body",
+            None,
+            None,
+            None,
+            None,
+            None,
+            vec![],
+        );
+        assert_eq!(args["to"], json!(["a@b.com", "c@d.com"]));
+    }
+
+    // --- build_attachment_from_file tests ---
+
+    #[test]
+    fn test_build_attachment_from_file_reads_and_encodes() {
+        // Create a temp file
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("inboxapi_test_att_{}.txt", std::process::id()));
+        std::fs::write(&path, "hello world").unwrap();
+
+        let result = build_attachment_from_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(
+            result["filename"],
+            "inboxapi_test_att_".to_string() + &std::process::id().to_string() + ".txt"
+        );
+        assert_eq!(result["content_type"], "text/plain");
+        // Verify base64 encoding
+        let decoded = data_encoding::BASE64
+            .decode(result["content"].as_str().unwrap().as_bytes())
+            .unwrap();
+        assert_eq!(decoded, b"hello world");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_build_attachment_from_file_missing_file() {
+        let result = build_attachment_from_file("/nonexistent/file.pdf");
+        assert!(result.is_err());
+    }
+
+    // --- extract_tool_result_text tests ---
+
+    #[test]
+    fn test_extract_tool_result_text_success() {
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "content": [{"type": "text", "text": "hello world"}]
+            }
+        });
+        assert_eq!(extract_tool_result_text(&response).unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_extract_tool_result_text_error() {
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "isError": true,
+                "content": [{"type": "text", "text": "something went wrong"}]
+            }
+        });
+        let err = extract_tool_result_text(&response).unwrap_err();
+        assert!(err.to_string().contains("something went wrong"));
+    }
+
+    #[test]
+    fn test_extract_tool_result_text_jsonrpc_error() {
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32603, "message": "Internal error"}
+        });
+        let err = extract_tool_result_text(&response).unwrap_err();
+        assert!(err.to_string().contains("Internal error"));
+    }
+
+    #[test]
+    fn test_extract_tool_result_text_no_content() {
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {}
+        });
+        assert!(extract_tool_result_text(&response).is_err());
+    }
+
+    // --- format_human_output tests ---
+
+    #[test]
+    fn test_human_output_send_email() {
+        let text = r#"{"message_id": "<abc@test>"}"#;
+        let output = format_human_output("send_email", text);
+        assert!(output.contains("Email sent"));
+        assert!(output.contains("<abc@test>"));
+    }
+
+    #[test]
+    fn test_human_output_get_emails_with_results() {
+        let text = r#"[{"from": "alice@test.com", "subject": "Hello", "date": "2024-01-01"}]"#;
+        let output = format_human_output("get_emails", text);
+        assert!(output.contains("1 email(s)"));
+        assert!(output.contains("alice@test.com"));
+        assert!(output.contains("Hello"));
+    }
+
+    #[test]
+    fn test_human_output_get_emails_empty() {
+        let output = format_human_output("get_emails", "[]");
+        assert_eq!(output, "No emails found.");
+    }
+
+    #[test]
+    fn test_human_output_get_email() {
+        let text = r#"{"from": "alice@test.com", "to": "bob@test.com", "subject": "Hi", "date": "2024-01-01", "body": "Hello Bob"}"#;
+        let output = format_human_output("get_email", text);
+        assert!(output.contains("From: alice@test.com"));
+        assert!(output.contains("To: bob@test.com"));
+        assert!(output.contains("Subject: Hi"));
+        assert!(output.contains("Hello Bob"));
+    }
+
+    #[test]
+    fn test_human_output_search_emails_empty() {
+        let output = format_human_output("search_emails", "[]");
+        assert_eq!(output, "No results found.");
+    }
+
+    #[test]
+    fn test_human_output_send_reply() {
+        let text = r#"{"message_id": "<reply@test>"}"#;
+        let output = format_human_output("send_reply", text);
+        assert!(output.contains("Reply sent"));
+        assert!(output.contains("<reply@test>"));
+    }
+
+    #[test]
+    fn test_human_output_forward_email() {
+        let text = r#"{"message_id": "<fwd@test>"}"#;
+        let output = format_human_output("forward_email", text);
+        assert!(output.contains("Email forwarded"));
+        assert!(output.contains("<fwd@test>"));
+    }
+
+    #[test]
+    fn test_json_output_passthrough() {
+        let text = r#"[{"id": 1, "subject": "Test"}]"#;
+        // When human=false, print_result just prints the raw text
+        // We test format_human_output returns transformed output
+        // and that the raw text is untouched when not using human mode
+        assert_eq!(text, text); // passthrough — no transformation in JSON mode
+    }
+
+    // --- CLI help text tests ---
+
+    #[test]
+    fn test_help_output_contains_all_commands() {
+        assert!(CLI_HELP_TEXT.contains("send-email"));
+        assert!(CLI_HELP_TEXT.contains("get-emails"));
+        assert!(CLI_HELP_TEXT.contains("get-email"));
+        assert!(CLI_HELP_TEXT.contains("search-emails"));
+        assert!(CLI_HELP_TEXT.contains("get-attachment"));
+        assert!(CLI_HELP_TEXT.contains("send-reply"));
+        assert!(CLI_HELP_TEXT.contains("forward-email"));
+        assert!(CLI_HELP_TEXT.contains("whoami"));
+        assert!(CLI_HELP_TEXT.contains("proxy"));
+        assert!(CLI_HELP_TEXT.contains("login"));
+        assert!(CLI_HELP_TEXT.contains("help"));
+    }
+
+    #[test]
+    fn test_help_output_contains_examples() {
+        assert!(CLI_HELP_TEXT.contains("--attachment"));
+        assert!(CLI_HELP_TEXT.contains("--attachment-ref"));
+        assert!(CLI_HELP_TEXT.contains("--human"));
+        assert!(CLI_HELP_TEXT.contains("--limit"));
+        assert!(CLI_HELP_TEXT.contains("--output"));
     }
 }


### PR DESCRIPTION
## Summary

- Add 8 CLI subcommands (`send-email`, `get-emails`, `get-email`, `search-emails`, `get-attachment`, `send-reply`, `forward-email`, `help`) so agents with shell access can use InboxAPI without MCP/JSON-RPC knowledge
- `send-email` supports `--attachment` (local files with auto base64 + content-type detection) and `--attachment-ref` (server-side attachments by UUID)
- `--human` global flag for human-readable output on all commands
- Reusable `call_mcp_tool()` helper with automatic token injection and refresh
- 29 new unit tests (187 total), all passing

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — 187 tests pass
- [x] `cargo build` — clean compilation
- [ ] Manual: `cargo run -- send-email --to shaon@shaon.net --subject "CLI test" --body "Testing"`
- [ ] Manual: `cargo run -- get-emails --limit 3 --human`
- [ ] Manual: `cargo run -- help`