### PR TITLE
chore: bump version to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "inboxapi-cli"
-version = "0.2.25"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inboxapi-cli"
-version = "0.2.25"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/npm/cli-darwin-arm64/package.json
+++ b/npm/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-darwin-arm64",
-  "version": "0.2.25",
+  "version": "0.3.0",
   "description": "InboxAPI CLI binary for macOS ARM64",
   "os": [
     "darwin"

--- a/npm/cli-darwin-x64/package.json
+++ b/npm/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-darwin-x64",
-  "version": "0.2.25",
+  "version": "0.3.0",
   "description": "InboxAPI CLI binary for macOS x64",
   "os": [
     "darwin"

--- a/npm/cli-linux-arm64/package.json
+++ b/npm/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-linux-arm64",
-  "version": "0.2.25",
+  "version": "0.3.0",
   "description": "InboxAPI CLI binary for Linux ARM64",
   "os": [
     "linux"

--- a/npm/cli-linux-x64/package.json
+++ b/npm/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-linux-x64",
-  "version": "0.2.25",
+  "version": "0.3.0",
   "description": "InboxAPI CLI binary for Linux x64",
   "os": [
     "linux"

--- a/npm/cli-win32-x64/package.json
+++ b/npm/cli-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli-win32-x64",
-  "version": "0.2.25",
+  "version": "0.3.0",
   "description": "InboxAPI CLI binary for Windows x64",
   "os": [
     "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli",
-  "version": "0.2.25",
+  "version": "0.3.0",
   "description": "📧 Email for your AI 🤖",
   "main": "index.js",
   "bin": {
@@ -35,6 +35,6 @@
     "@inboxapi/cli-win32-x64": "0.1.0"
   },
   "dependencies": {
-    "@inboxapi/cli": "^0.2.25"
+    "@inboxapi/cli": "^0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,5 @@
     "@inboxapi/cli-linux-arm64": "0.1.0",
     "@inboxapi/cli-linux-x64": "0.1.0",
     "@inboxapi/cli-win32-x64": "0.1.0"
-  },
-  "dependencies": {
-    "@inboxapi/cli": "^0.3.0"
   }
 }


### PR DESCRIPTION
## Summary

- Bump version to 0.3.0 for release with CLI subcommands feature

This follows the fix commit on main that corrected:
- `search-emails` args to match actual MCP API (`--sender`, `--subject`, `--since`, `--until` instead of `--query`)
- `get-attachment` to use `download_url` field from server response
- `--human` output formatting for wrapped `{"emails": [...]}` responses
- clap help subcommand conflict

## Test plan
- [x] All 190 tests pass
- [x] All CLI subcommands tested live against the API
- [x] `cargo fmt`, `cargo clippy`, `cargo build` all clean