### PR TITLE
feat: add missing CLI subcommands and migrate skills to CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,20 @@ Rust-based STDIO proxy that bridges JSON-RPC (MCP protocol) over STDIO to the re
 - `cargo run -- get-attachment <id> --output ./file.pdf` — download an attachment
 - `cargo run -- send-reply --message-id "<id>" --body "Reply"` — reply to an email
 - `cargo run -- forward-email --message-id "<id>" --to user@example.com` — forward an email
+- `cargo run -- get-last-email` — get the most recent email
+- `cargo run -- get-email-count` — get inbox email count (optional `--since`)
+- `cargo run -- get-sent-emails --limit 10` — list sent emails
+- `cargo run -- get-thread --message-id "<id>"` — get an email thread
+- `cargo run -- get-addressbook` — get address book contacts
+- `cargo run -- get-announcements` — get InboxAPI announcements
+- `cargo run -- auth-introspect` — introspect current access token
+- `cargo run -- auth-revoke --token "<token>"` — revoke a specific token
+- `cargo run -- auth-revoke-all` — revoke all tokens
+- `cargo run -- account-recover --name "x" --email "y"` — recover a lost account
+- `cargo run -- verify-owner --email "x"` — verify email ownership
+- `cargo run -- enable-encryption` — enable email encryption
+- `cargo run -- reset-encryption` — reset email encryption
+- `cargo run -- rotate-encryption --old-secret "x" --new-secret "y"` — rotate encryption secret
 - `cargo run -- help` — show CLI help with examples
 
 ## Architecture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "inboxapi-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inboxapi-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [dependencies]

--- a/claude/hooks/email-activity-logger.js
+++ b/claude/hooks/email-activity-logger.js
@@ -19,13 +19,26 @@ function main() {
   const toolInput = data.tool_input || {};
   const cwd = data.cwd || process.cwd();
 
-  // Only log inboxapi tools
-  if (!toolName.includes("inboxapi")) {
+  // Only log inboxapi tools (MCP or CLI via Bash)
+  let shortName;
+  if (toolName === "Bash") {
+    const cmd = (toolInput.command || "");
+    if (!cmd.includes("inboxapi")) {
+      process.exit(0);
+    }
+    // Extract subcommand: first arg after "inboxapi" that doesn't start with --
+    const parts = cmd.split(/\s+/);
+    const idx = parts.findIndex(p => p === "inboxapi" || p.endsWith("/inboxapi"));
+    shortName = (idx >= 0 && parts[idx + 1] && !parts[idx + 1].startsWith("-"))
+      ? parts[idx + 1]
+      : "unknown-cli-cmd";
+  } else if (toolName.includes("inboxapi")) {
+    shortName = toolName.replace("mcp__inboxapi__", "");
+  } else {
     process.exit(0);
   }
 
   const timestamp = new Date().toISOString();
-  const shortName = toolName.replace("mcp__inboxapi__", "");
 
   // Build a concise log entry (logs identifiers and lengths, not email content)
   let details = "";

--- a/claude/hooks/email-send-guard.js
+++ b/claude/hooks/email-send-guard.js
@@ -17,25 +17,50 @@ function main() {
   const toolName = data.tool_name || "";
   const toolInput = data.tool_input || {};
 
-  // Only inspect send-related tools
-  if (
-    !toolName.includes("send_email") &&
-    !toolName.includes("send_reply") &&
-    !toolName.includes("forward_email")
-  ) {
-    process.exit(0);
-  }
+  let toDisplay, subject, body, action;
 
-  const rawTo = toolInput.to || toolInput.recipient || "(unknown)";
-  const toList = Array.isArray(rawTo) ? rawTo : [rawTo];
-  const toDisplay = toList.join(", ");
-  const subject = toolInput.subject || "(no subject)";
-  const body = toolInput.body || toolInput.message || "";
-  const action = toolName.includes("forward")
-    ? "FORWARD"
-    : toolName.includes("reply")
-      ? "REPLY"
-      : "SEND";
+  if (toolName === "Bash") {
+    // Check if this is an inboxapi CLI send command
+    const cmd = (toolInput.command || "");
+    if (!cmd.includes("inboxapi")) {
+      process.exit(0);
+    }
+    const isSend = cmd.includes("send-email");
+    const isReply = cmd.includes("send-reply");
+    const isForward = cmd.includes("forward-email");
+    if (!isSend && !isReply && !isForward) {
+      process.exit(0);
+    }
+
+    // Best-effort extraction from CLI flags
+    const toMatch = cmd.match(/--to\s+(?:"([^"]+)"|'([^']+)'|(\S+))/);
+    toDisplay = (toMatch && (toMatch[1] || toMatch[2] || toMatch[3])) || "(unknown)";
+    const subjectMatch = cmd.match(/--subject\s+(?:"([^"]+)"|'([^']+)'|(\S+))/);
+    subject = (subjectMatch && (subjectMatch[1] || subjectMatch[2] || subjectMatch[3])) || "(no subject)";
+    const bodyMatch = cmd.match(/--body\s+(?:"([^"]+)"|'([^']+)'|(\S+))/);
+    body = (bodyMatch && (bodyMatch[1] || bodyMatch[2] || bodyMatch[3])) || "";
+    action = isForward ? "FORWARD" : isReply ? "REPLY" : "SEND";
+  } else {
+    // MCP tool call path (existing logic)
+    if (
+      !toolName.includes("send_email") &&
+      !toolName.includes("send_reply") &&
+      !toolName.includes("forward_email")
+    ) {
+      process.exit(0);
+    }
+
+    const rawTo = toolInput.to || toolInput.recipient || "(unknown)";
+    const toList = Array.isArray(rawTo) ? rawTo : [rawTo];
+    toDisplay = toList.join(", ");
+    subject = toolInput.subject || "(no subject)";
+    body = toolInput.body || toolInput.message || "";
+    action = toolName.includes("forward")
+      ? "FORWARD"
+      : toolName.includes("reply")
+        ? "REPLY"
+        : "SEND";
+  }
 
   // Log details to stderr so the user sees them in the Claude Code UI
   process.stderr.write(`\n[InboxAPI Send Guard] ${action}\n`);
@@ -48,9 +73,7 @@ function main() {
   process.stderr.write("\n");
 
   // Check for self-send (common AI agent mistake)
-  const hasInboxApiRecipient = toList.some(
-    (addr) => typeof addr === "string" && (addr.includes("@inboxapi.ai") || addr.includes("@inboxapi.com")),
-  );
+  const hasInboxApiRecipient = toDisplay.includes("@inboxapi.ai") || toDisplay.includes("@inboxapi.com");
   if (hasInboxApiRecipient) {
     process.stderr.write(
       `  [WARNING] Recipient is an @inboxapi address. Did you mean to send to an external address?\n\n`,

--- a/claude/skills/check-inbox/SKILL.md
+++ b/claude/skills/check-inbox/SKILL.md
@@ -11,10 +11,9 @@ Fetch and display a summary of recent emails from the user's InboxAPI inbox.
 
 ## Steps
 
-1. Call the `mcp__inboxapi__whoami` tool to identify the current account and email address
-2. Call `mcp__inboxapi__get_email_count` to show the total number of emails
-3. Call `mcp__inboxapi__get_emails` with:
-   - `limit`: Use `$ARGUMENTS` if provided, otherwise default to `20`
+1. Run: `npx -y @inboxapi/cli whoami` to identify the current account and email address
+2. Run: `npx -y @inboxapi/cli get-email-count` to show the total number of emails
+3. Run: `npx -y @inboxapi/cli get-emails --limit <N>` where `<N>` is `$ARGUMENTS` if provided, otherwise `20`
 4. Present results in a formatted table with columns:
    - **From** — sender name or address
    - **Subject** — email subject line (truncated to 60 chars)
@@ -35,5 +34,6 @@ If the inbox is empty, display: "Your inbox is empty. Your email address is <ema
 
 ## Notes
 
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
 - Do NOT read full email bodies — only show the summary list
-- If the user asks to read a specific email after seeing the list, use `mcp__inboxapi__get_email` with the email ID
+- If the user asks to read a specific email after seeing the list, run `npx -y @inboxapi/cli get-email "<message-id>"` with the email ID

--- a/claude/skills/compose/SKILL.md
+++ b/claude/skills/compose/SKILL.md
@@ -12,11 +12,11 @@ Guide the user through composing and sending an email safely.
 
 ## Steps
 
-1. **Identify sender**: Call `mcp__inboxapi__whoami` to get the current account email address
+1. **Identify sender**: Run: `npx -y @inboxapi/cli whoami` to get the current account email address
 
 2. **Resolve recipient**:
    - If `$ARGUMENTS` is provided, use it as the recipient hint
-   - Call `mcp__inboxapi__get_addressbook` to check for matching contacts
+   - Run: `npx -y @inboxapi/cli get-addressbook` to check for matching contacts
    - If multiple matches found, ask the user to pick one
    - If no match, ask the user to confirm or provide the full email address
 
@@ -41,13 +41,17 @@ Guide the user through composing and sending an email safely.
 
 6. **Confirm**: Ask the user to confirm: "Send this email? (yes/no)"
 
-7. **Send**: Call `mcp__inboxapi__send_email` with `to`, `subject`, and `body`
+7. **Send**: Run: `npx -y @inboxapi/cli send-email --to "<recipient>" --subject "<subject>" --body "<body>"`
 
 8. **Confirm delivery**: Report the result to the user
+
+## Notes
+
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
 
 ## Rules
 
 - ALWAYS show a preview before sending
-- ALWAYS ask for explicit confirmation before calling send_email
+- ALWAYS ask for explicit confirmation before calling send-email
 - NEVER send an email without the user confirming
 - If the user cancels, acknowledge and do not send

--- a/claude/skills/email-digest/SKILL.md
+++ b/claude/skills/email-digest/SKILL.md
@@ -13,13 +13,13 @@ Generate a structured digest of recent email activity.
 
 1. **Determine timeframe**: Use `$ARGUMENTS` if provided (e.g., "today", "this week", "last 3 days"), otherwise default to "last 24 hours"
 
-2. **Get account info**: Call `mcp__inboxapi__whoami` for the account email
+2. **Get account info**: Run: `npx -y @inboxapi/cli whoami` for the account email
 
-3. **Get total count**: Call `mcp__inboxapi__get_email_count` for inbox statistics
+3. **Get total count**: Run: `npx -y @inboxapi/cli get-email-count` for inbox statistics
 
-4. **Fetch recent emails**: Call `mcp__inboxapi__get_emails` with an appropriate limit (50 for digest)
+4. **Fetch recent emails**: Run: `npx -y @inboxapi/cli get-emails --limit 50`
 
-5. **Group by thread**: For threads with multiple emails, call `mcp__inboxapi__get_thread` to understand the conversation
+5. **Group by thread**: For threads with multiple emails, run `npx -y @inboxapi/cli get-thread --message-id "<message-id>"` to understand the conversation
 
 6. **Generate digest** with these sections:
 
@@ -53,6 +53,7 @@ Generate a structured digest of recent email activity.
 
 ## Notes
 
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
 - Focus on actionable insights, not raw data
 - Highlight emails that likely need a response
 - Keep the digest concise — summarize, don't reproduce full emails

--- a/claude/skills/email-forward/SKILL.md
+++ b/claude/skills/email-forward/SKILL.md
@@ -13,8 +13,8 @@ Help the user forward an email to another recipient.
 ## Steps
 
 1. **Find the email to forward**:
-   - If `$ARGUMENTS` looks like an email ID, call `mcp__inboxapi__get_email` directly
-   - Otherwise, call `mcp__inboxapi__search_emails` with the argument
+   - If `$ARGUMENTS` looks like an email ID, run `npx -y @inboxapi/cli get-email "<message-id>"` directly
+   - Otherwise, run `npx -y @inboxapi/cli search-emails --subject "<query>"` with the argument
    - If multiple results, show them and ask the user to pick one
 
 2. **Show email content**: Display the email being forwarded:
@@ -29,7 +29,7 @@ Help the user forward an email to another recipient.
 
 3. **Resolve recipient**:
    - Ask "Who do you want to forward this to?"
-   - Call `mcp__inboxapi__get_addressbook` to check for matching contacts
+   - Run: `npx -y @inboxapi/cli get-addressbook` to check for matching contacts
    - Confirm the recipient email address
 
 4. **Optional message**: Ask "Add a message? (or press enter to skip)"
@@ -44,7 +44,11 @@ Help the user forward an email to another recipient.
 
 6. **Confirm**: Ask "Forward this email? (yes/no)"
 
-7. **Send**: Call `mcp__inboxapi__forward_email` with the email ID, recipient, and optional message
+7. **Send**: Run: `npx -y @inboxapi/cli forward-email --message-id "<id>" --to "<recipient>"` (add `--note "<message>"` if provided)
+
+## Notes
+
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
 
 ## Rules
 

--- a/claude/skills/email-reply/SKILL.md
+++ b/claude/skills/email-reply/SKILL.md
@@ -13,11 +13,11 @@ Help the user reply to an email with full thread context.
 ## Steps
 
 1. **Find the email**:
-   - If `$ARGUMENTS` looks like an email ID (alphanumeric string), call `mcp__inboxapi__get_email` directly
-   - Otherwise, call `mcp__inboxapi__search_emails` with the argument as subject/keyword
+   - If `$ARGUMENTS` looks like an email ID (alphanumeric string), run `npx -y @inboxapi/cli get-email "<message-id>"` directly
+   - Otherwise, run `npx -y @inboxapi/cli search-emails --subject "<query>"` with the argument as subject/keyword
    - If multiple results, present them and ask the user to pick one
 
-2. **Load thread context**: Call `mcp__inboxapi__get_thread` with the email's thread ID to show the full conversation
+2. **Load thread context**: Run: `npx -y @inboxapi/cli get-thread --message-id "<message-id>"` with the email's thread ID to show the full conversation
 
 3. **Display thread**: Show the conversation history in chronological order:
    ```
@@ -45,7 +45,11 @@ Help the user reply to an email with full thread context.
 
 6. **Confirm**: Ask "Send this reply? (yes/no)"
 
-7. **Send**: Call `mcp__inboxapi__send_reply` with the email ID and reply body
+7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
+
+## Notes
+
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
 
 ## Rules
 

--- a/claude/skills/email-search/SKILL.md
+++ b/claude/skills/email-search/SKILL.md
@@ -14,13 +14,13 @@ Search emails using natural language and present results clearly.
 1. Take the user's query from `$ARGUMENTS`
    - If no arguments provided, ask: "What are you looking for?"
 
-2. Translate the natural language query into a `mcp__inboxapi__search_emails` call:
-   - Extract sender hints (e.g., "from John" -> search by sender)
-   - Extract subject hints (e.g., "about invoices" -> search by subject)
-   - Extract date hints (e.g., "last week", "yesterday")
-   - Use the full query as the search term
+2. Translate the natural language query into CLI flags for `search-emails`:
+   - Extract sender hints (e.g., "from John" -> `--sender "John"`)
+   - Extract subject hints (e.g., "about invoices" -> `--subject "invoices"`)
+   - Extract date hints (e.g., "last week", "yesterday" -> `--since "..."`, `--until "..."`)
+   - Combine with `--limit` as needed
 
-3. Call `mcp__inboxapi__search_emails` with the interpreted parameters
+3. Run: `npx -y @inboxapi/cli search-emails` with the appropriate flags (`--sender "..."`, `--subject "..."`, `--since "..."`, `--until "..."`)
 
 4. Present results in a formatted table:
    ```
@@ -30,9 +30,13 @@ Search emails using natural language and present results clearly.
 
 5. After showing results, offer: "Would you like to read any of these emails? Provide the number."
 
-6. If the user picks one, call `mcp__inboxapi__get_email` with the email ID
+6. If the user picks one, run `npx -y @inboxapi/cli get-email "<message-id>"` with the email ID
 
 7. If no results, suggest alternative searches or broader terms
+
+## Notes
+
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
 
 ## Examples
 

--- a/claude/skills/setup-inboxapi/SKILL.md
+++ b/claude/skills/setup-inboxapi/SKILL.md
@@ -31,7 +31,7 @@ Configure InboxAPI email tools for this Claude Code project.
 3. **Install skills**: Run `npx -y @inboxapi/cli setup-skills` to copy bundled skills and hooks into the project's `.claude/` directory
 
 4. **Verify credentials**:
-   - Call `mcp__inboxapi__whoami` to check if credentials are set up
+   - Run: `npx -y @inboxapi/cli whoami` to check if credentials are set up
    - If not authenticated, instruct the user: "Run `npx -y @inboxapi/cli login` in a terminal to authenticate"
 
 5. **Show summary**:
@@ -61,6 +61,7 @@ Configure InboxAPI email tools for this Claude Code project.
 
 ## Notes
 
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
 - This skill is safe to run multiple times — it won't duplicate entries or overwrite local edits
 - Existing `.mcp.json` entries, skill files, and hook files with local edits are preserved
 - `.claude/settings.json` is merged with new hook config (may be reformatted when hooks are updated)

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,80 @@ enum Commands {
         #[arg(long)]
         note: Option<String>,
     },
+    /// Get the most recent email
+    GetLastEmail,
+    /// Get inbox email count
+    GetEmailCount {
+        /// Only count emails since this ISO 8601 datetime
+        #[arg(long)]
+        since: Option<String>,
+    },
+    /// List sent emails
+    GetSentEmails {
+        /// Filter by status
+        #[arg(long)]
+        status: Option<String>,
+        /// Maximum number of results
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Offset for pagination
+        #[arg(long)]
+        offset: Option<u32>,
+    },
+    /// Get an email thread by message ID
+    GetThread {
+        /// The message ID to get the thread for
+        #[arg(long)]
+        message_id: String,
+    },
+    /// Get your address book contacts
+    GetAddressbook,
+    /// Get InboxAPI announcements
+    GetAnnouncements,
+    /// Introspect the current access token
+    AuthIntrospect,
+    /// Revoke a specific token
+    AuthRevoke {
+        /// The token to revoke
+        #[arg(long)]
+        token: String,
+    },
+    /// Revoke all tokens for the current account
+    AuthRevokeAll,
+    /// Recover a lost account
+    AccountRecover {
+        /// Account name
+        #[arg(long)]
+        name: String,
+        /// Recovery email address
+        #[arg(long)]
+        email: String,
+        /// Recovery code (if already received)
+        #[arg(long)]
+        code: Option<String>,
+    },
+    /// Verify email ownership
+    VerifyOwner {
+        /// Email address to verify
+        #[arg(long)]
+        email: String,
+        /// Verification code (if already received)
+        #[arg(long)]
+        code: Option<String>,
+    },
+    /// Enable email encryption
+    EnableEncryption,
+    /// Reset email encryption
+    ResetEncryption,
+    /// Rotate encryption secret
+    RotateEncryption {
+        /// Current encryption secret
+        #[arg(long)]
+        old_secret: String,
+        /// New encryption secret
+        #[arg(long)]
+        new_secret: String,
+    },
     /// Show CLI help with examples
     Help,
 }
@@ -554,7 +628,7 @@ static HOOKS_SETTINGS: &str = r#"{
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "mcp__inboxapi__send_email|mcp__inboxapi__send_reply|mcp__inboxapi__forward_email",
+        "matcher": "mcp__inboxapi__send_email|mcp__inboxapi__send_reply|mcp__inboxapi__forward_email|Bash",
         "hooks": [
           {
             "type": "command",
@@ -566,7 +640,7 @@ static HOOKS_SETTINGS: &str = r#"{
     ],
     "PostToolUse": [
       {
-        "matcher": "mcp__inboxapi__.*",
+        "matcher": "mcp__inboxapi__.*|Bash",
         "hooks": [
           {
             "type": "command",
@@ -795,6 +869,20 @@ async fn main() -> Result<()> {
         | Some(Commands::GetAttachment { .. })
         | Some(Commands::SendReply { .. })
         | Some(Commands::ForwardEmail { .. })
+        | Some(Commands::GetLastEmail)
+        | Some(Commands::GetEmailCount { .. })
+        | Some(Commands::GetSentEmails { .. })
+        | Some(Commands::GetThread { .. })
+        | Some(Commands::GetAddressbook)
+        | Some(Commands::GetAnnouncements)
+        | Some(Commands::AuthIntrospect)
+        | Some(Commands::AuthRevoke { .. })
+        | Some(Commands::AuthRevokeAll)
+        | Some(Commands::AccountRecover { .. })
+        | Some(Commands::VerifyOwner { .. })
+        | Some(Commands::EnableEncryption)
+        | Some(Commands::ResetEncryption)
+        | Some(Commands::RotateEncryption { .. })
         | Some(Commands::Help) => run_cli_command(&cli).await,
         None => {
             // Prefer the endpoint stored in credentials, if available; fall back to CLI default.
@@ -1244,6 +1332,97 @@ fn format_human_output(tool_name: &str, text: &str) -> String {
                 format!("Email forwarded.\n{}", text)
             }
         }
+        "get_last_email" => {
+            // Reuse the get_email formatter
+            format_human_output("get_email", text)
+        }
+        "get_email_count" => {
+            if let Ok(data) = serde_json::from_str::<Value>(text) {
+                let count = data["count"]
+                    .as_u64()
+                    .or_else(|| data["total"].as_u64())
+                    .unwrap_or(0);
+                format!("Email count: {}", count)
+            } else {
+                text.to_string()
+            }
+        }
+        "get_sent_emails" => {
+            // Reuse the get_emails formatter
+            format_human_output("get_emails", text)
+        }
+        "get_thread" => {
+            if let Ok(data) = serde_json::from_str::<Value>(text) {
+                let messages = data["messages"]
+                    .as_array()
+                    .or_else(|| data["emails"].as_array())
+                    .or_else(|| data.as_array());
+                if let Some(msgs) = messages {
+                    let mut lines = Vec::new();
+                    for (i, msg) in msgs.iter().enumerate() {
+                        let from = msg["from"]
+                            .as_str()
+                            .or_else(|| msg["sender"].as_str())
+                            .unwrap_or("unknown");
+                        let date = msg["date"]
+                            .as_str()
+                            .or_else(|| msg["received_at"].as_str())
+                            .unwrap_or("");
+                        let body = msg["body"]
+                            .as_str()
+                            .or_else(|| msg["text_body"].as_str())
+                            .unwrap_or("");
+                        let preview = if body.chars().count() > 100 {
+                            let truncated: String = body.chars().take(100).collect();
+                            format!("{}...", truncated)
+                        } else {
+                            body.to_string()
+                        };
+                        lines.push(format!(
+                            "[{}] From: {} ({})\n  {}",
+                            i + 1,
+                            from,
+                            date,
+                            preview
+                        ));
+                    }
+                    let subject = data["subject"].as_str().unwrap_or("(thread)");
+                    format!("Thread: {}\n{}", subject, lines.join("\n\n"))
+                } else {
+                    text.to_string()
+                }
+            } else {
+                text.to_string()
+            }
+        }
+        "get_addressbook" => {
+            if let Ok(data) = serde_json::from_str::<Value>(text) {
+                let contacts = data["contacts"].as_array().or_else(|| data.as_array());
+                if let Some(contacts) = contacts {
+                    if contacts.is_empty() {
+                        return "Address book is empty.".to_string();
+                    }
+                    let mut lines = Vec::new();
+                    for contact in contacts {
+                        let name = contact["name"].as_str().unwrap_or("");
+                        let email = contact["email"]
+                            .as_str()
+                            .or_else(|| contact["address"].as_str())
+                            .unwrap_or("unknown");
+                        if name.is_empty() {
+                            lines.push(format!("  {}", email));
+                        } else {
+                            lines.push(format!("  {} <{}>", name, email));
+                        }
+                    }
+                    format!("{} contact(s):\n{}", contacts.len(), lines.join("\n"))
+                } else {
+                    text.to_string()
+                }
+            } else {
+                text.to_string()
+            }
+        }
         _ => text.to_string(),
     }
 }
@@ -1264,10 +1443,24 @@ Commands:
   send-email     Send an email (supports --attachment and --attachment-ref)
   get-emails     List inbox emails
   get-email      Get a single email by message ID
+  get-last-email  Get the most recent email
+  get-email-count  Get inbox email count
+  get-sent-emails  List sent emails
+  get-thread     Get an email thread
   search-emails  Search your inbox
   get-attachment  Get or download an attachment
   send-reply     Reply to an email
   forward-email  Forward an email
+  get-addressbook  Get your address book contacts
+  get-announcements  Get InboxAPI announcements
+  auth-introspect  Introspect the current access token
+  auth-revoke    Revoke a specific token
+  auth-revoke-all  Revoke all tokens
+  account-recover  Recover a lost account
+  verify-owner   Verify email ownership
+  enable-encryption  Enable email encryption
+  reset-encryption  Reset email encryption
+  rotate-encryption  Rotate encryption secret
   whoami         Show current account info
   proxy          Start MCP STDIO proxy (default)
   login          Create account and store credentials
@@ -1283,6 +1476,11 @@ Examples:
   inboxapi send-email --to user@example.com --subject \"Fwd\" --body \"See attached\" --attachment-ref 9f0206bb-...
   inboxapi get-emails --limit 5
   inboxapi get-emails --limit 5 --human
+  inboxapi get-last-email
+  inboxapi get-email-count
+  inboxapi get-sent-emails --limit 10
+  inboxapi get-thread --message-id \"<msg-id>\"
+  inboxapi get-addressbook
   inboxapi search-emails --subject \"invoice\"
   inboxapi get-attachment abc123 --output ./file.pdf
   inboxapi send-reply --message-id \"<msg-id>\" --body \"Thanks!\"
@@ -1491,6 +1689,177 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "forward_email", args).await?;
             let text = extract_tool_result_text(&response)?;
             print_result("forward_email", &text, cli.human);
+        }
+        Some(Commands::GetLastEmail) => {
+            let response = call_mcp_tool(
+                &endpoint,
+                &mut creds,
+                &http_client,
+                "get_last_email",
+                json!({}),
+            )
+            .await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("get_last_email", &text, cli.human);
+        }
+        Some(Commands::GetEmailCount { ref since }) => {
+            let mut args = json!({});
+            if let Some(since) = since {
+                args["since"] = json!(since);
+            }
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "get_email_count", args).await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("get_email_count", &text, cli.human);
+        }
+        Some(Commands::GetSentEmails {
+            ref status,
+            limit,
+            offset,
+        }) => {
+            let mut args = json!({});
+            if let Some(status) = status {
+                args["status"] = json!(status);
+            }
+            if let Some(limit) = limit {
+                args["limit"] = json!(limit);
+            }
+            if let Some(offset) = offset {
+                args["offset"] = json!(offset);
+            }
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "get_sent_emails", args).await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("get_sent_emails", &text, cli.human);
+        }
+        Some(Commands::GetThread { ref message_id }) => {
+            let args = json!({"message_id": message_id});
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "get_thread", args).await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("get_thread", &text, cli.human);
+        }
+        Some(Commands::GetAddressbook) => {
+            let response = call_mcp_tool(
+                &endpoint,
+                &mut creds,
+                &http_client,
+                "get_addressbook",
+                json!({}),
+            )
+            .await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("get_addressbook", &text, cli.human);
+        }
+        Some(Commands::GetAnnouncements) => {
+            let response = call_mcp_tool(
+                &endpoint,
+                &mut creds,
+                &http_client,
+                "get_announcements",
+                json!({}),
+            )
+            .await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("get_announcements", &text, cli.human);
+        }
+        Some(Commands::AuthIntrospect) => {
+            let response = call_mcp_tool(
+                &endpoint,
+                &mut creds,
+                &http_client,
+                "auth_introspect",
+                json!({}),
+            )
+            .await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("auth_introspect", &text, cli.human);
+        }
+        Some(Commands::AuthRevoke { ref token }) => {
+            let args = json!({"token": token});
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "auth_revoke", args).await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("auth_revoke", &text, cli.human);
+        }
+        Some(Commands::AuthRevokeAll) => {
+            let response = call_mcp_tool(
+                &endpoint,
+                &mut creds,
+                &http_client,
+                "auth_revoke_all",
+                json!({}),
+            )
+            .await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("auth_revoke_all", &text, cli.human);
+        }
+        Some(Commands::AccountRecover {
+            ref name,
+            ref email,
+            ref code,
+        }) => {
+            let mut args = json!({"name": name, "email": email});
+            if let Some(code) = code {
+                args["code"] = json!(code);
+            }
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("account_recover", &text, cli.human);
+        }
+        Some(Commands::VerifyOwner {
+            ref email,
+            ref code,
+        }) => {
+            let mut args = json!({"email": email});
+            if let Some(code) = code {
+                args["code"] = json!(code);
+            }
+            let response =
+                call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("verify_owner", &text, cli.human);
+        }
+        Some(Commands::EnableEncryption) => {
+            let response = call_mcp_tool(
+                &endpoint,
+                &mut creds,
+                &http_client,
+                "enable_encryption",
+                json!({}),
+            )
+            .await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("enable_encryption", &text, cli.human);
+        }
+        Some(Commands::ResetEncryption) => {
+            let response = call_mcp_tool(
+                &endpoint,
+                &mut creds,
+                &http_client,
+                "reset_encryption",
+                json!({}),
+            )
+            .await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("reset_encryption", &text, cli.human);
+        }
+        Some(Commands::RotateEncryption {
+            ref old_secret,
+            ref new_secret,
+        }) => {
+            let args = json!({"old_secret": old_secret, "new_secret": new_secret});
+            let response = call_mcp_tool(
+                &endpoint,
+                &mut creds,
+                &http_client,
+                "rotate_encryption_secret",
+                args,
+            )
+            .await?;
+            let text = extract_tool_result_text(&response)?;
+            print_result("rotate_encryption_secret", &text, cli.human);
         }
         Some(Commands::Help) => {
             print!("{}", CLI_HELP_TEXT);


### PR DESCRIPTION
## Summary

- Add 14 new CLI subcommands covering all remaining MCP tools (get-last-email, get-email-count, get-sent-emails, get-thread, get-addressbook, get-announcements, auth-introspect, auth-revoke, auth-revoke-all, account-recover, verify-owner, enable-encryption, reset-encryption, rotate-encryption)
- Update hooks (email-send-guard, email-activity-logger) to detect inboxapi CLI commands invoked via the Bash tool alongside existing MCP tool call detection
- Migrate all 7 skills from `mcp__inboxapi__*` tool calls to `npx -y @inboxapi/cli <subcommand>` Bash commands, enabling smaller models without MCP server setup
- Update CLAUDE.md docs and bump version to 0.3.1

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (zero warnings)
- [x] `cargo test` passes (190 tests)
- [x] `cargo build` compiles cleanly
- [x] `cargo run -- help` shows all new subcommands
- [ ] Smoke test new subcommands: `get-last-email`, `get-email-count`, `get-addressbook`
- [ ] Verify skills work via `/check-inbox`, `/compose`, `/email-search`
- [ ] Verify hooks fire on Bash-based send operations