### PR TITLE
feat: add CC, BCC, and reply-all support to send-reply

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Rust-based STDIO proxy that bridges JSON-RPC (MCP protocol) over STDIO to the re
 - `cargo run -- get-email "<message-id>"` — get a single email
 - `cargo run -- search-emails --subject "keyword"` — search emails
 - `cargo run -- get-attachment <id> --output ./file.pdf` — download an attachment
-- `cargo run -- send-reply --message-id "<id>" --body "Reply"` — reply to an email
+- `cargo run -- send-reply --message-id "<id>" --body "Reply"` — reply to an email (optional: `--cc`, `--bcc`, `--reply-all`, `--html-body`, `--from-name`, `--priority`)
 - `cargo run -- forward-email --message-id "<id>" --to user@example.com` — forward an email
 - `cargo run -- get-last-email` — get the most recent email
 - `cargo run -- get-email-count` — get inbox email count (optional `--since`)

--- a/skills/claude/email-reply/SKILL.md
+++ b/skills/claude/email-reply/SKILL.md
@@ -58,7 +58,7 @@ Help the user reply to an email with full thread context.
    - `--reply-all` — reply to all recipients in the thread
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--from-name "Name"` — override sender display name
-   - `--priority "high|normal|low"` — set email priority
+   - `--priority <high|normal|low>` — set email priority
 
 ## Notes
 

--- a/skills/claude/email-reply/SKILL.md
+++ b/skills/claude/email-reply/SKILL.md
@@ -47,6 +47,19 @@ Help the user reply to an email with full thread context.
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
 
+   **Preserving CC recipients in threads**: If the thread has CC'd recipients, include them with `--cc`:
+   ```
+   npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>" --cc "cc1@example.com,cc2@example.com"
+   ```
+
+   **Additional options**:
+   - `--cc "addr1,addr2"` — CC recipients (comma-separated)
+   - `--bcc "addr1,addr2"` — BCC recipients (comma-separated, silent copy)
+   - `--reply-all` — reply to all recipients in the thread
+   - `--html-body "<html>"` — send HTML-formatted reply
+   - `--from-name "Name"` — override sender display name
+   - `--priority "high|normal|low"` — set email priority
+
 ## Notes
 
 - All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
@@ -56,3 +69,4 @@ Help the user reply to an email with full thread context.
 - ALWAYS show the thread context before composing
 - ALWAYS preview and confirm before sending
 - NEVER send without explicit user confirmation
+- When replying to threads with CC'd recipients, ALWAYS preserve them using `--cc` to avoid breaking the chain

--- a/skills/codex/email-reply/SKILL.md
+++ b/skills/codex/email-reply/SKILL.md
@@ -44,6 +44,19 @@ Help the user reply to an email with full thread context.
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
 
+   **Preserving CC recipients in threads**: If the thread has CC'd recipients, include them with `--cc`:
+   ```
+   npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>" --cc "cc1@example.com,cc2@example.com"
+   ```
+
+   **Additional options**:
+   - `--cc "addr1,addr2"` — CC recipients (comma-separated)
+   - `--bcc "addr1,addr2"` — BCC recipients (comma-separated, silent copy)
+   - `--reply-all` — reply to all recipients in the thread
+   - `--html-body "<html>"` — send HTML-formatted reply
+   - `--from-name "Name"` — override sender display name
+   - `--priority "high|normal|low"` — set email priority
+
 ## Notes
 
 - All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
@@ -53,3 +66,4 @@ Help the user reply to an email with full thread context.
 - ALWAYS show the thread context before composing
 - ALWAYS preview and confirm before sending
 - NEVER send without explicit user confirmation
+- When replying to threads with CC'd recipients, ALWAYS preserve them using `--cc` to avoid breaking the chain

--- a/skills/codex/email-reply/SKILL.md
+++ b/skills/codex/email-reply/SKILL.md
@@ -55,7 +55,7 @@ Help the user reply to an email with full thread context.
    - `--reply-all` — reply to all recipients in the thread
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--from-name "Name"` — override sender display name
-   - `--priority "high|normal|low"` — set email priority
+   - `--priority <high|normal|low>` — set email priority
 
 ## Notes
 

--- a/skills/gemini/email-reply/SKILL.md
+++ b/skills/gemini/email-reply/SKILL.md
@@ -44,6 +44,19 @@ Help the user reply to an email with full thread context.
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
 
+   **Preserving CC recipients in threads**: If the thread has CC'd recipients, include them with `--cc`:
+   ```
+   npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>" --cc "cc1@example.com,cc2@example.com"
+   ```
+
+   **Additional options**:
+   - `--cc "addr1,addr2"` — CC recipients (comma-separated)
+   - `--bcc "addr1,addr2"` — BCC recipients (comma-separated, silent copy)
+   - `--reply-all` — reply to all recipients in the thread
+   - `--html-body "<html>"` — send HTML-formatted reply
+   - `--from-name "Name"` — override sender display name
+   - `--priority "high|normal|low"` — set email priority
+
 ## Notes
 
 - All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
@@ -53,3 +66,4 @@ Help the user reply to an email with full thread context.
 - ALWAYS show the thread context before composing
 - ALWAYS preview and confirm before sending
 - NEVER send without explicit user confirmation
+- When replying to threads with CC'd recipients, ALWAYS preserve them using `--cc` to avoid breaking the chain

--- a/skills/gemini/email-reply/SKILL.md
+++ b/skills/gemini/email-reply/SKILL.md
@@ -55,7 +55,7 @@ Help the user reply to an email with full thread context.
    - `--reply-all` — reply to all recipients in the thread
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--from-name "Name"` — override sender display name
-   - `--priority "high|normal|low"` — set email priority
+   - `--priority <high|normal|low>` — set email priority
 
 ## Notes
 

--- a/skills/opencode/email-reply.md
+++ b/skills/opencode/email-reply.md
@@ -43,6 +43,19 @@ Help the user reply to an email with full thread context.
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
 
+   **Preserving CC recipients in threads**: If the thread has CC'd recipients, include them with `--cc`:
+   ```
+   npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>" --cc "cc1@example.com,cc2@example.com"
+   ```
+
+   **Additional options**:
+   - `--cc "addr1,addr2"` — CC recipients (comma-separated)
+   - `--bcc "addr1,addr2"` — BCC recipients (comma-separated, silent copy)
+   - `--reply-all` — reply to all recipients in the thread
+   - `--html-body "<html>"` — send HTML-formatted reply
+   - `--from-name "Name"` — override sender display name
+   - `--priority "high|normal|low"` — set email priority
+
 ## Notes
 
 - All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
@@ -52,3 +65,4 @@ Help the user reply to an email with full thread context.
 - ALWAYS show the thread context before composing
 - ALWAYS preview and confirm before sending
 - NEVER send without explicit user confirmation
+- When replying to threads with CC'd recipients, ALWAYS preserve them using `--cc` to avoid breaking the chain

--- a/skills/opencode/email-reply.md
+++ b/skills/opencode/email-reply.md
@@ -54,7 +54,7 @@ Help the user reply to an email with full thread context.
    - `--reply-all` — reply to all recipients in the thread
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--from-name "Name"` — override sender display name
-   - `--priority "high|normal|low"` — set email priority
+   - `--priority <high|normal|low>` — set email priority
 
 ## Notes
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,24 @@ enum Commands {
         /// Reply body (plain text)
         #[arg(long)]
         body: String,
+        /// CC recipients, comma-separated
+        #[arg(long)]
+        cc: Option<String>,
+        /// BCC recipients, comma-separated
+        #[arg(long)]
+        bcc: Option<String>,
+        /// HTML body
+        #[arg(long)]
+        html_body: Option<String>,
+        /// Sender display name
+        #[arg(long)]
+        from_name: Option<String>,
+        /// Reply to all recipients in the thread
+        #[arg(long)]
+        reply_all: bool,
+        /// Priority: low, normal, or high
+        #[arg(long)]
+        priority: Option<String>,
     },
     /// Forward an email
     ForwardEmail {
@@ -2157,11 +2175,35 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
         Some(Commands::SendReply {
             ref message_id,
             ref body,
+            ref cc,
+            ref bcc,
+            ref html_body,
+            ref from_name,
+            reply_all,
+            ref priority,
         }) => {
-            let args = json!({
+            let mut args = json!({
                 "in_reply_to": message_id,
                 "body": body,
             });
+            if reply_all {
+                args["reply_all"] = json!(true);
+            }
+            if let Some(cc) = cc {
+                args["cc"] = json!(split_csv(cc));
+            }
+            if let Some(bcc) = bcc {
+                args["bcc"] = json!(split_csv(bcc));
+            }
+            if let Some(html_body) = html_body {
+                args["html_body"] = json!(html_body);
+            }
+            if let Some(from_name) = from_name {
+                args["from_name"] = json!(from_name);
+            }
+            if let Some(priority) = priority {
+                args["priority"] = json!(priority);
+            }
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "send_reply", args).await?;
             let text = extract_tool_result_text(&response)?;


### PR DESCRIPTION
## Summary

- Adds `--cc`, `--bcc`, `--reply-all`, `--html-body`, `--from-name`, and `--priority` flags to the `send-reply` CLI subcommand
- Fixes broken email chains where CC'd recipients were dropped when agents replied via CLI
- Updates all 4 agent skill files (Claude, Codex, Gemini, OpenCode) to document new options and instruct agents to preserve CC recipients

## Context

The remote MCP endpoint already supported `cc`, `bcc`, `reply_all`, `html_body`, `from_name`, and `priority` on `send_reply` — existing tests verified passthrough. The gap was purely at the CLI layer where only `--message-id` and `--body` were exposed.

## Test plan

- [x] `cargo fmt` — no changes
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — all 223 tests pass (existing passthrough tests cover the new fields)
- [x] `cargo build` — clean compilation
- [x] `cargo run -- send-reply --help` — shows all new flags