### PR TITLE
feat: add MCP integration tests and LLM evaluation script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,26 @@ Cargo.toml                     — Rust dependencies
 - Do not add AI attribution to commits, code, or comments
 - Keep `src/main.rs` as a single file — this is a simple proxy, not a framework
 
+## Coding Standards
+
+### Rust
+- Always implement `Drop` for structs that own child processes or OS resources — assertion panics must not leak processes
+- Never re-create buffered readers (`BufReader`) in a loop or per-call; store them in the struct so buffered data is not lost
+- Use iterators (`iter().take(n)`) instead of index-based `for i in 0..n` loops when only indexing a single collection
+- Add timeouts to any blocking I/O (network, subprocess reads) — tests and tools must not hang indefinitely
+- Include descriptive messages in all `assert!` / `assert_eq!` macros
+
+### JavaScript / Node.js
+- Never use `execSync` / `execFileSync` with string interpolation — pass arguments as arrays to avoid shell injection
+- Do not mark synchronous functions `async` — it is misleading and wraps the return in an unnecessary Promise
+- Handle chunked `data` events from child process stdout with line-based parsing (e.g. `readline.createInterface`), not raw `JSON.parse` on each chunk
+- When communicating with a subprocess over its lifetime, spawn it once and reuse the connection — do not spawn a new process per request
+- Validate all user input (bounds checks, type checks) before using it to index arrays or build commands
+- Use environment variables or constants for model identifiers — never hardcode dated model version strings
+
+### MCP Protocol
+- After sending `initialize`, always send `notifications/initialized` before any other requests — skipping this violates the MCP handshake and may cause server rejection
+
 ## Pre-completion Checklist
 Before declaring work done, run these in order:
 1. `cargo fmt` — format code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Cargo.toml                     — Rust dependencies
 - Handle chunked `data` events from child process stdout with line-based parsing (e.g. `readline.createInterface`), not raw `JSON.parse` on each chunk
 - When communicating with a subprocess over its lifetime, spawn it once and reuse the connection — do not spawn a new process per request
 - Validate all user input (bounds checks, type checks) before using it to index arrays or build commands
-- Use environment variables or constants for model identifiers — never hardcode dated model version strings
+- Centralize model identifiers in a single constant or environment variable; avoid scattering hardcoded dated model version strings throughout the code
 
 ### MCP Protocol
 - After sending `initialize`, always send `notifications/initialized` before any other requests — skipping this violates the MCP handshake and may cause server rejection

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -59,3 +59,30 @@ Users install with `npm install -g @inboxapi/cli`. npm automatically selects the
 - Do not add AI attribution to commits, code, or comments
 - Run `cargo fmt` before committing Rust changes
 - Use conventional commits (`feat:`, `fix:`, `chore:`, etc.)
+
+## Coding Standards
+
+### Rust
+- Implement `Drop` for structs owning child processes or OS resources — panics must not leak processes
+- Store `BufReader` in structs rather than re-creating per call — re-creation loses buffered data
+- Prefer iterators (`iter().take(n)`) over index loops (`for i in 0..n`) when indexing a single collection
+- Add timeouts to all blocking I/O — tests and tools must not hang indefinitely
+- Include descriptive messages in all assertions
+
+### JavaScript / Node.js
+- Pass arguments as arrays to `execFileSync` — never use string interpolation with `execSync` (shell injection risk)
+- Do not declare synchronous functions as `async`
+- Use line-based parsing (`readline.createInterface`) for child process stdout — raw `data` events are chunked arbitrarily
+- Spawn subprocesses once and reuse — do not spawn a new process per request
+- Validate user input before using it to index arrays or build commands
+- Use environment variables or constants for model identifiers — never hardcode dated model strings
+
+### MCP Protocol
+- Always send `notifications/initialized` after `initialize` and before any other requests
+
+## Pre-completion Checklist
+Before declaring work done, run in order:
+1. `cargo fmt` — format code
+2. `cargo clippy -- -D warnings` — lint with zero warnings
+3. `cargo test` — all unit tests pass
+4. `cargo build` — clean compilation

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -75,7 +75,7 @@ Users install with `npm install -g @inboxapi/cli`. npm automatically selects the
 - Use line-based parsing (`readline.createInterface`) for child process stdout — raw `data` events are chunked arbitrarily
 - Spawn subprocesses once and reuse — do not spawn a new process per request
 - Validate user input before using it to index arrays or build commands
-- Use environment variables or constants for model identifiers — never hardcode dated model strings
+- Centralize model identifiers in a single constant or environment variable; avoid scattering hardcoded dated model version strings throughout the code
 
 ### MCP Protocol
 - Always send `notifications/initialized` after `initialize` and before any other requests

--- a/eval/README.md
+++ b/eval/README.md
@@ -1,0 +1,30 @@
+# InboxAPI Agent Evaluation Script
+
+This script evaluates how well an LLM (Claude) understands and uses the InboxAPI CLI tools via the MCP protocol.
+
+## Prerequisites
+
+1.  **Anthropic API Key:** Set the `ANTHROPIC_API_KEY` environment variable.
+2.  **InboxAPI Authentication:** Ensure you are logged in (`cargo run -- login`).
+3.  **Recent Contacts:** You must have at least one contact in your addressbook (`cargo run -- get-addressbook`).
+4.  **Node.js:** Installed and available.
+
+## Setup
+
+```bash
+cd eval
+npm install
+```
+
+## Running Evaluations
+
+```bash
+node index.js
+```
+
+The script will:
+1.  Verify your InboxAPI authentication.
+2.  Retrieve your recent contacts and ask you to select one as a test recipient.
+3.  Provide Claude with your current MCP tool definitions.
+4.  Run a series of natural language prompts ("intents") and verify that Claude generates the correct tool calls.
+5.  Execute those tool calls against the local CLI proxy to verify end-to-end connectivity.

--- a/eval/index.js
+++ b/eval/index.js
@@ -1,10 +1,9 @@
-const { spawn, execSync } = require('child_process');
+const { spawn, execFileSync } = require('child_process');
 const readline = require('readline');
 const Anthropic = require('@anthropic-ai/sdk');
 
-// Configuration
-const CARGO_RUN = 'cargo run --';
 const WORKTREE_DIR = '..'; // Assuming this is run from eval/
+const DEFAULT_MODEL = 'claude-sonnet-4-5-20250514';
 
 const rl = readline.createInterface({
     input: process.stdin,
@@ -13,128 +12,152 @@ const rl = readline.createInterface({
 
 const question = (query) => new Promise((resolve) => rl.question(query, resolve));
 
-async function runCommand(command) {
-    return execSync(`${CARGO_RUN} ${command}`, { cwd: WORKTREE_DIR, encoding: 'utf-8' });
+function runCommand(...args) {
+    return execFileSync('cargo', ['run', '--', ...args], { cwd: WORKTREE_DIR, encoding: 'utf-8' });
 }
 
-async function getTools() {
-    return new Promise((resolve, reject) => {
-        const proc = spawn('cargo', ['run', '--', 'proxy'], { cwd: WORKTREE_DIR });
-        let output = '';
-        
-        proc.stdout.on('data', (data) => {
-            const line = data.toString();
+class ProxyClient {
+    constructor() {
+        this._proc = null;
+        this._lineReader = null;
+        this._lineBuffer = [];
+        this._lineWaiters = [];
+        this._nextId = 1;
+    }
+
+    async start() {
+        this._proc = spawn('cargo', ['run', '--', 'proxy'], {
+            cwd: WORKTREE_DIR,
+            stdio: ['pipe', 'pipe', 'inherit']
+        });
+
+        this._lineReader = readline.createInterface({ input: this._proc.stdout });
+        this._lineReader.on('line', (line) => {
+            const trimmed = line.trim();
+            if (!trimmed) return;
             try {
-                const json = JSON.parse(line);
-                if (json.result && json.result.tools) {
-                    proc.kill();
-                    resolve(json.result.tools);
+                const parsed = JSON.parse(trimmed);
+                if (this._lineWaiters.length > 0) {
+                    const { resolve } = this._lineWaiters.shift();
+                    resolve(parsed);
+                } else {
+                    this._lineBuffer.push(parsed);
                 }
-            } catch (e) {
-                // Ignore non-json output (like cargo build messages)
+            } catch {
+                // Ignore non-JSON output (e.g., cargo build messages)
             }
         });
 
-        proc.stdin.write(JSON.stringify({
-            jsonrpc: "2.0",
-            id: 1,
-            method: "initialize",
+        // Initialize
+        this._send({
+            jsonrpc: '2.0',
+            id: this._nextId++,
+            method: 'initialize',
             params: {
-                protocolVersion: "2024-11-05",
+                protocolVersion: '2024-11-05',
                 capabilities: {},
-                clientInfo: { name: "eval-script", version: "1.0.0" }
-            }
-        }) + '\n');
-
-        proc.stdin.write(JSON.stringify({
-            jsonrpc: "2.0",
-            id: 2,
-            method: "tools/list"
-        }) + '\n');
-        
-        setTimeout(() => {
-            proc.kill();
-            reject(new Error('Timeout getting tools'));
-        }, 10000);
-    });
-}
-
-async function callTool(name, args) {
-    return new Promise((resolve, reject) => {
-        const proc = spawn('cargo', ['run', '--', 'proxy'], { cwd: WORKTREE_DIR });
-        let responseReceived = false;
-
-        proc.stdout.on('data', (data) => {
-            const lines = data.toString().split('\n');
-            for (const line of lines) {
-                if (!line.trim()) continue;
-                try {
-                    const json = JSON.parse(line);
-                    if (json.id === 3) {
-                        responseReceived = true;
-                        proc.kill();
-                        resolve(json.result);
-                    }
-                } catch (e) {}
+                clientInfo: { name: 'eval-script', version: '1.0.0' }
             }
         });
 
-        proc.stdin.write(JSON.stringify({
-            jsonrpc: "2.0",
-            id: 1,
-            method: "initialize",
-            params: {
-                protocolVersion: "2024-11-05",
-                capabilities: {},
-                clientInfo: { name: "eval-script", version: "1.0.0" }
-            }
-        }) + '\n');
+        const initResponse = await this._receive(10000);
+        if (!initResponse.result) {
+            throw new Error(`Initialize failed: ${JSON.stringify(initResponse)}`);
+        }
 
-        proc.stdin.write(JSON.stringify({
-            jsonrpc: "2.0",
-            id: 3,
-            method: "tools/call",
-            params: {
-                name: name,
-                arguments: args
-            }
-        }) + '\n');
+        // Send initialized notification
+        this._send({
+            jsonrpc: '2.0',
+            method: 'notifications/initialized'
+        });
 
-        setTimeout(() => {
-            if (!responseReceived) {
-                proc.kill();
-                reject(new Error(`Timeout calling tool ${name}`));
+        return initResponse;
+    }
+
+    _send(message) {
+        this._proc.stdin.write(JSON.stringify(message) + '\n');
+    }
+
+    _receive(timeoutMs = 30000) {
+        return new Promise((resolve, reject) => {
+            if (this._lineBuffer.length > 0) {
+                resolve(this._lineBuffer.shift());
+                return;
             }
-        }, 30000);
-    });
+
+            const timer = setTimeout(() => {
+                const idx = this._lineWaiters.findIndex((w) => w.resolve === resolve);
+                if (idx !== -1) this._lineWaiters.splice(idx, 1);
+                reject(new Error(`Timeout after ${timeoutMs}ms waiting for response`));
+            }, timeoutMs);
+
+            this._lineWaiters.push({
+                resolve: (value) => {
+                    clearTimeout(timer);
+                    resolve(value);
+                }
+            });
+        });
+    }
+
+    async getTools() {
+        this._send({
+            jsonrpc: '2.0',
+            id: this._nextId++,
+            method: 'tools/list'
+        });
+        const response = await this._receive(10000);
+        return response.result.tools;
+    }
+
+    async callTool(name, args) {
+        this._send({
+            jsonrpc: '2.0',
+            id: this._nextId++,
+            method: 'tools/call',
+            params: { name, arguments: args }
+        });
+        return this._receive(30000);
+    }
+
+    close() {
+        if (this._lineReader) this._lineReader.close();
+        if (this._proc) this._proc.kill();
+    }
 }
 
 async function main() {
     console.log('--- InboxAPI Agent Evaluation ---');
-    
+
     // 1. Check Auth
     try {
-        const whoami = JSON.parse(await runCommand('whoami'));
+        const whoami = JSON.parse(runCommand('whoami'));
         console.log(`Authenticated as: ${whoami.account_name} (${whoami.email})`);
-    } catch (e) {
+    } catch {
         console.error('Error: Not authenticated. Run `cargo run -- login` first.');
         process.exit(1);
     }
 
     // 2. Get Addressbook
-    const addressbookData = JSON.parse(await runCommand('get-addressbook'));
+    const addressbookData = JSON.parse(runCommand('get-addressbook'));
     const contacts = addressbookData.addressbook;
-    
-    if (contacts.length === 0) {
+
+    if (!contacts || contacts.length === 0) {
         console.error('Error: Addressbook is empty. Cannot run evaluations.');
         process.exit(1);
     }
 
+    const maxContacts = Math.min(contacts.length, 5);
     console.log('\nRecent Contacts:');
-    contacts.slice(0, 5).forEach((c, i) => console.log(`${i + 1}. ${c.email}`));
-    
-    const choice = await question('\nSelect a contact for integration tests (1-5): ');
-    const testEmail = contacts[parseInt(choice) - 1].email;
+    contacts.slice(0, maxContacts).forEach((c, i) => console.log(`${i + 1}. ${c.email}`));
+
+    const choice = await question(`\nSelect a contact for integration tests (1-${maxContacts}): `);
+    const choiceNum = parseInt(choice, 10);
+    if (isNaN(choiceNum) || choiceNum < 1 || choiceNum > maxContacts) {
+        console.error(`Invalid selection. Enter a number between 1 and ${maxContacts}.`);
+        process.exit(1);
+    }
+    const testEmail = contacts[choiceNum - 1].email;
     console.log(`Using ${testEmail} for tests.`);
 
     // 3. Setup LLM
@@ -144,57 +167,74 @@ async function main() {
     }
 
     const anthropic = new Anthropic();
-    const tools = await getTools();
-    
-    // Map MCP tools to Anthropic tool format
-    const anthropicTools = tools.map(t => ({
-        name: t.name,
-        description: t.description,
-        input_schema: t.inputSchema
-    }));
+    const model = process.env.EVAL_MODEL || DEFAULT_MODEL;
 
-    const coreIntents = [
-        {
-            name: 'Send Email',
-            prompt: `Send a short greeting email to ${testEmail} with subject "Integration Test" and body "Hello from the eval script!"`
-        },
-        {
-            name: 'List Emails',
-            prompt: 'Get the last 3 emails from my inbox.'
-        }
-    ];
+    // 4. Start proxy
+    const proxy = new ProxyClient();
+    try {
+        await proxy.start();
+        const tools = await proxy.getTools();
 
-    for (const intent of coreIntents) {
-        console.log(`\nEvaluating intent: ${intent.name}...`);
-        
-        let messages = [{ role: 'user', content: intent.prompt }];
-        
-        const response = await anthropic.messages.create({
-            model: 'claude-3-5-sonnet-20240620',
-            max_tokens: 1024,
-            tools: anthropicTools,
-            messages: messages
-        });
+        // Map MCP tools to Anthropic tool format
+        const anthropicTools = tools.map((t) => ({
+            name: t.name,
+            description: t.description,
+            input_schema: t.inputSchema
+        }));
 
-        console.log('Claude response:', response.content.filter(c => c.type === 'text').map(c => c.text).join('\n'));
-        
-        const toolCalls = response.content.filter(c => c.type === 'tool_use');
-        if (toolCalls.length > 0) {
-            for (const toolUse of toolCalls) {
-                console.log(`Calling tool: ${toolUse.name} with args:`, toolUse.input);
-                try {
-                    const result = await callTool(toolUse.name, toolUse.input);
-                    console.log(`Tool ${toolUse.name} result received.`);
-                    // We could feed this back to Claude for a final confirmation, 
-                    // but for "intent validation", seeing the tool call is usually enough.
-                } catch (e) {
-                    console.error(`Tool call failed: ${e.message}`);
-                }
+        const coreIntents = [
+            {
+                name: 'Send Email',
+                expectedTool: 'send_email',
+                prompt: `Send a short greeting email to ${testEmail} with subject "Integration Test" and body "Hello from the eval script!"`
+            },
+            {
+                name: 'List Emails',
+                expectedTool: 'get_emails',
+                prompt: 'Get the last 3 emails from my inbox.'
             }
-            console.log(`[PASS] ${intent.name}`);
-        } else {
-            console.log(`[FAIL] ${intent.name} - No tool call generated.`);
+        ];
+
+        for (const intent of coreIntents) {
+            console.log(`\nEvaluating intent: ${intent.name}...`);
+
+            const response = await anthropic.messages.create({
+                model,
+                max_tokens: 1024,
+                tools: anthropicTools,
+                messages: [{ role: 'user', content: intent.prompt }]
+            });
+
+            const textParts = response.content.filter((c) => c.type === 'text');
+            if (textParts.length > 0) {
+                console.log('LLM response:', textParts.map((c) => c.text).join('\n'));
+            }
+
+            const toolCalls = response.content.filter((c) => c.type === 'tool_use');
+            if (toolCalls.length === 0) {
+                console.log(`[FAIL] ${intent.name} - No tool call generated.`);
+                continue;
+            }
+
+            const matchingCall = toolCalls.find((tc) => tc.name === intent.expectedTool);
+            if (!matchingCall) {
+                console.log(
+                    `[FAIL] ${intent.name} - Expected tool ${intent.expectedTool}, got: ${toolCalls.map((tc) => tc.name).join(', ')}`
+                );
+                continue;
+            }
+
+            console.log(`Calling tool: ${matchingCall.name} with args:`, matchingCall.input);
+            try {
+                await proxy.callTool(matchingCall.name, matchingCall.input);
+                console.log(`Tool ${matchingCall.name} result received.`);
+                console.log(`[PASS] ${intent.name}`);
+            } catch (e) {
+                console.error(`[FAIL] ${intent.name} - Tool call failed: ${e.message}`);
+            }
         }
+    } finally {
+        proxy.close();
     }
 
     rl.close();

--- a/eval/index.js
+++ b/eval/index.js
@@ -2,8 +2,10 @@ const { spawn, execFileSync } = require('child_process');
 const readline = require('readline');
 const Anthropic = require('@anthropic-ai/sdk');
 
-const WORKTREE_DIR = '..'; // Assuming this is run from eval/
-const DEFAULT_MODEL = 'claude-sonnet-4-5-20250514';
+const path = require('path');
+
+const WORKTREE_DIR = path.join(__dirname, '..');
+const DEFAULT_MODEL = 'claude-sonnet-4-5-latest';
 
 const rl = readline.createInterface({
     input: process.stdin,
@@ -226,7 +228,10 @@ async function main() {
 
             console.log(`Calling tool: ${matchingCall.name} with args:`, matchingCall.input);
             try {
-                await proxy.callTool(matchingCall.name, matchingCall.input);
+                const toolResult = await proxy.callTool(matchingCall.name, matchingCall.input);
+                if (toolResult.error || (toolResult.result && toolResult.result.isError)) {
+                    throw new Error(`Tool returned error: ${JSON.stringify(toolResult.error || toolResult.result)}`);
+                }
                 console.log(`Tool ${matchingCall.name} result received.`);
                 console.log(`[PASS] ${intent.name}`);
             } catch (e) {

--- a/eval/index.js
+++ b/eval/index.js
@@ -1,0 +1,203 @@
+const { spawn, execSync } = require('child_process');
+const readline = require('readline');
+const Anthropic = require('@anthropic-ai/sdk');
+
+// Configuration
+const CARGO_RUN = 'cargo run --';
+const WORKTREE_DIR = '..'; // Assuming this is run from eval/
+
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+});
+
+const question = (query) => new Promise((resolve) => rl.question(query, resolve));
+
+async function runCommand(command) {
+    return execSync(`${CARGO_RUN} ${command}`, { cwd: WORKTREE_DIR, encoding: 'utf-8' });
+}
+
+async function getTools() {
+    return new Promise((resolve, reject) => {
+        const proc = spawn('cargo', ['run', '--', 'proxy'], { cwd: WORKTREE_DIR });
+        let output = '';
+        
+        proc.stdout.on('data', (data) => {
+            const line = data.toString();
+            try {
+                const json = JSON.parse(line);
+                if (json.result && json.result.tools) {
+                    proc.kill();
+                    resolve(json.result.tools);
+                }
+            } catch (e) {
+                // Ignore non-json output (like cargo build messages)
+            }
+        });
+
+        proc.stdin.write(JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+                protocolVersion: "2024-11-05",
+                capabilities: {},
+                clientInfo: { name: "eval-script", version: "1.0.0" }
+            }
+        }) + '\n');
+
+        proc.stdin.write(JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            method: "tools/list"
+        }) + '\n');
+        
+        setTimeout(() => {
+            proc.kill();
+            reject(new Error('Timeout getting tools'));
+        }, 10000);
+    });
+}
+
+async function callTool(name, args) {
+    return new Promise((resolve, reject) => {
+        const proc = spawn('cargo', ['run', '--', 'proxy'], { cwd: WORKTREE_DIR });
+        let responseReceived = false;
+
+        proc.stdout.on('data', (data) => {
+            const lines = data.toString().split('\n');
+            for (const line of lines) {
+                if (!line.trim()) continue;
+                try {
+                    const json = JSON.parse(line);
+                    if (json.id === 3) {
+                        responseReceived = true;
+                        proc.kill();
+                        resolve(json.result);
+                    }
+                } catch (e) {}
+            }
+        });
+
+        proc.stdin.write(JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+                protocolVersion: "2024-11-05",
+                capabilities: {},
+                clientInfo: { name: "eval-script", version: "1.0.0" }
+            }
+        }) + '\n');
+
+        proc.stdin.write(JSON.stringify({
+            jsonrpc: "2.0",
+            id: 3,
+            method: "tools/call",
+            params: {
+                name: name,
+                arguments: args
+            }
+        }) + '\n');
+
+        setTimeout(() => {
+            if (!responseReceived) {
+                proc.kill();
+                reject(new Error(`Timeout calling tool ${name}`));
+            }
+        }, 30000);
+    });
+}
+
+async function main() {
+    console.log('--- InboxAPI Agent Evaluation ---');
+    
+    // 1. Check Auth
+    try {
+        const whoami = JSON.parse(await runCommand('whoami'));
+        console.log(`Authenticated as: ${whoami.account_name} (${whoami.email})`);
+    } catch (e) {
+        console.error('Error: Not authenticated. Run `cargo run -- login` first.');
+        process.exit(1);
+    }
+
+    // 2. Get Addressbook
+    const addressbookData = JSON.parse(await runCommand('get-addressbook'));
+    const contacts = addressbookData.addressbook;
+    
+    if (contacts.length === 0) {
+        console.error('Error: Addressbook is empty. Cannot run evaluations.');
+        process.exit(1);
+    }
+
+    console.log('\nRecent Contacts:');
+    contacts.slice(0, 5).forEach((c, i) => console.log(`${i + 1}. ${c.email}`));
+    
+    const choice = await question('\nSelect a contact for integration tests (1-5): ');
+    const testEmail = contacts[parseInt(choice) - 1].email;
+    console.log(`Using ${testEmail} for tests.`);
+
+    // 3. Setup LLM
+    if (!process.env.ANTHROPIC_API_KEY) {
+        console.error('Error: ANTHROPIC_API_KEY environment variable is not set.');
+        process.exit(1);
+    }
+
+    const anthropic = new Anthropic();
+    const tools = await getTools();
+    
+    // Map MCP tools to Anthropic tool format
+    const anthropicTools = tools.map(t => ({
+        name: t.name,
+        description: t.description,
+        input_schema: t.inputSchema
+    }));
+
+    const coreIntents = [
+        {
+            name: 'Send Email',
+            prompt: `Send a short greeting email to ${testEmail} with subject "Integration Test" and body "Hello from the eval script!"`
+        },
+        {
+            name: 'List Emails',
+            prompt: 'Get the last 3 emails from my inbox.'
+        }
+    ];
+
+    for (const intent of coreIntents) {
+        console.log(`\nEvaluating intent: ${intent.name}...`);
+        
+        let messages = [{ role: 'user', content: intent.prompt }];
+        
+        const response = await anthropic.messages.create({
+            model: 'claude-3-5-sonnet-20240620',
+            max_tokens: 1024,
+            tools: anthropicTools,
+            messages: messages
+        });
+
+        console.log('Claude response:', response.content.filter(c => c.type === 'text').map(c => c.text).join('\n'));
+        
+        const toolCalls = response.content.filter(c => c.type === 'tool_use');
+        if (toolCalls.length > 0) {
+            for (const toolUse of toolCalls) {
+                console.log(`Calling tool: ${toolUse.name} with args:`, toolUse.input);
+                try {
+                    const result = await callTool(toolUse.name, toolUse.input);
+                    console.log(`Tool ${toolUse.name} result received.`);
+                    // We could feed this back to Claude for a final confirmation, 
+                    // but for "intent validation", seeing the tool call is usually enough.
+                } catch (e) {
+                    console.error(`Tool call failed: ${e.message}`);
+                }
+            }
+            console.log(`[PASS] ${intent.name}`);
+        } else {
+            console.log(`[FAIL] ${intent.name} - No tool call generated.`);
+        }
+    }
+
+    rl.close();
+}
+
+main().catch(console.error);

--- a/eval/index.js
+++ b/eval/index.js
@@ -1,8 +1,7 @@
 const { spawn, execFileSync } = require('child_process');
 const readline = require('readline');
-const Anthropic = require('@anthropic-ai/sdk');
-
 const path = require('path');
+const Anthropic = require('@anthropic-ai/sdk');
 
 const WORKTREE_DIR = path.join(__dirname, '..');
 const DEFAULT_MODEL = 'claude-sonnet-4-5-latest';
@@ -40,8 +39,8 @@ class ProxyClient {
             try {
                 const parsed = JSON.parse(trimmed);
                 if (this._lineWaiters.length > 0) {
-                    const { resolve } = this._lineWaiters.shift();
-                    resolve(parsed);
+                    const waiter = this._lineWaiters.shift();
+                    waiter.resolve(parsed);
                 } else {
                     this._lineBuffer.push(parsed);
                 }
@@ -87,18 +86,26 @@ class ProxyClient {
                 return;
             }
 
+            let settled = false;
+
             const timer = setTimeout(() => {
-                const idx = this._lineWaiters.findIndex((w) => w.resolve === resolve);
+                if (settled) return;
+                settled = true;
+                const idx = this._lineWaiters.findIndex((w) => w === waiter);
                 if (idx !== -1) this._lineWaiters.splice(idx, 1);
                 reject(new Error(`Timeout after ${timeoutMs}ms waiting for response`));
             }, timeoutMs);
 
-            this._lineWaiters.push({
+            const waiter = {
                 resolve: (value) => {
+                    if (settled) return;
+                    settled = true;
                     clearTimeout(timer);
                     resolve(value);
                 }
-            });
+            };
+
+            this._lineWaiters.push(waiter);
         });
     }
 
@@ -131,18 +138,18 @@ class ProxyClient {
 async function main() {
     console.log('--- InboxAPI Agent Evaluation ---');
 
-    // 1. Check Auth
+    // 1. Check Auth — whoami outputs human-readable text, not JSON
     try {
-        const whoami = JSON.parse(runCommand('whoami'));
-        console.log(`Authenticated as: ${whoami.account_name} (${whoami.email})`);
+        const whoamiOutput = runCommand('whoami').trim();
+        console.log(whoamiOutput);
     } catch {
         console.error('Error: Not authenticated. Run `cargo run -- login` first.');
         process.exit(1);
     }
 
-    // 2. Get Addressbook
+    // 2. Get Addressbook — CLI outputs raw JSON from the MCP tool
     const addressbookData = JSON.parse(runCommand('get-addressbook'));
-    const contacts = addressbookData.addressbook;
+    const contacts = addressbookData.contacts || addressbookData.addressbook;
 
     if (!contacts || contacts.length === 0) {
         console.error('Error: Addressbook is empty. Cannot run evaluations.');

--- a/eval/package-lock.json
+++ b/eval/package-lock.json
@@ -1,0 +1,64 @@
+{
+  "name": "eval",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "eval",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.80.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
+      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/eval/package-lock.json
+++ b/eval/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "eval",
+  "name": "@inboxapi/eval",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "eval",
+      "name": "@inboxapi/eval",
       "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0"
       }

--- a/eval/package.json
+++ b/eval/package.json
@@ -1,14 +1,12 @@
 {
-  "name": "eval",
+  "name": "@inboxapi/eval",
   "version": "1.0.0",
-  "description": "",
+  "description": "LLM evaluation script for InboxAPI MCP tool usage",
+  "private": true,
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "eval": "node index.js"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "type": "commonjs",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0"

--- a/eval/package.json
+++ b/eval/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "eval",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.80.0"
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4657,27 +4657,27 @@ mod tests {
         let tools = parsed["result"]["tools"].as_array().unwrap();
 
         // send_email, send_reply, forward_email should contain identity
-        for i in 0..3 {
-            let desc = tools[i]["description"].as_str().unwrap();
+        for tool in tools.iter().take(3) {
+            let desc = tool["description"].as_str().unwrap();
             assert!(
                 desc.contains("cool-agent"),
                 "tool {} missing name",
-                tools[i]["name"]
+                tool["name"]
             );
             assert!(
                 desc.contains("cool-agent@inboxapi.io"),
                 "tool {} missing email",
-                tools[i]["name"]
+                tool["name"]
             );
             assert!(
                 desc.contains("Cool Agent"),
                 "tool {} missing display name",
-                tools[i]["name"]
+                tool["name"]
             );
             assert!(
                 desc.contains("do not sign as the AI model"),
                 "tool {} missing signing guidance",
-                tools[i]["name"]
+                tool["name"]
             );
         }
         // get_emails should NOT be annotated

--- a/tests/mcp_integration_test.rs
+++ b/tests/mcp_integration_test.rs
@@ -1,21 +1,27 @@
+use serde_json::{json, Value};
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, Command, Stdio};
-use serde_json::{json, Value};
+use std::time::{Duration, Instant};
+
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 struct McpTestClient {
     child: Child,
+    reader: BufReader<std::process::ChildStdout>,
 }
 
 impl McpTestClient {
     fn spawn() -> Self {
-        let child = Command::new("cargo")
+        let mut child = Command::new("cargo")
             .args(["run", "--", "proxy"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .spawn()
             .expect("Failed to spawn cargo run -- proxy");
-        Self { child }
+        let stdout = child.stdout.take().expect("Failed to take stdout");
+        let reader = BufReader::new(stdout);
+        Self { child, reader }
     }
 
     fn send(&mut self, request: Value) {
@@ -26,15 +32,35 @@ impl McpTestClient {
     }
 
     fn receive(&mut self) -> Value {
-        let stdout = self.child.stdout.as_mut().expect("Failed to open stdout");
-        let mut reader = BufReader::new(stdout);
-        let mut line = String::new();
-        reader.read_line(&mut line).expect("Failed to read from stdout");
-        serde_json::from_str(&line).expect("Failed to deserialize response")
+        let start = Instant::now();
+        loop {
+            let mut line = String::new();
+            let bytes = self
+                .reader
+                .read_line(&mut line)
+                .expect("Failed to read from stdout");
+            if bytes == 0 {
+                if start.elapsed() > READ_TIMEOUT {
+                    panic!("Timeout after {:?} waiting for MCP response", READ_TIMEOUT);
+                }
+                std::thread::sleep(Duration::from_millis(50));
+                continue;
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            return serde_json::from_str(trimmed).unwrap_or_else(|e| {
+                panic!("Failed to deserialize response: {e}\nLine: {trimmed}")
+            });
+        }
     }
+}
 
-    fn kill(mut self) {
+impl Drop for McpTestClient {
+    fn drop(&mut self) {
         let _ = self.child.kill();
+        let _ = self.child.wait();
     }
 }
 
@@ -58,9 +84,17 @@ fn test_mcp_handshake() {
     }));
 
     let response = client.receive();
-    assert_eq!(response["id"], 1);
-    assert!(response["result"]["protocolVersion"].is_string());
-    assert!(response["result"]["capabilities"]["tools"].is_object());
+    assert_eq!(response["id"], 1, "Expected initialize response id=1");
+    assert!(
+        response["result"]["protocolVersion"].is_string(),
+        "protocolVersion should be a string, got: {}",
+        response
+    );
+    assert!(
+        response["result"]["capabilities"]["tools"].is_object(),
+        "capabilities.tools should be an object, got: {}",
+        response
+    );
 
     // 2. Initialized notification
     client.send(json!({
@@ -76,19 +110,22 @@ fn test_mcp_handshake() {
     }));
 
     let response = client.receive();
-    assert_eq!(response["id"], 2);
-    let tools = response["result"]["tools"].as_array().expect("Tools should be an array");
+    assert_eq!(response["id"], 2, "Expected tools/list response id=2");
+    let tools = response["result"]["tools"]
+        .as_array()
+        .expect("Tools should be an array");
     assert!(!tools.is_empty(), "Tool list should not be empty");
 
-    // Check for core tools
-    let tool_names: Vec<&str> = tools.iter()
-        .map(|t| t["name"].as_str().unwrap())
-        .collect();
-    
-    println!("Actual tool names: {:?}", tool_names);
-    
-    assert!(tool_names.contains(&"get_emails"), "Missing get_emails in {:?}", tool_names);
-    assert!(tool_names.contains(&"send_email"), "Missing send_email in {:?}", tool_names);
+    let tool_names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
 
-    client.kill();
+    assert!(
+        tool_names.contains(&"get_emails"),
+        "Missing get_emails in {:?}",
+        tool_names
+    );
+    assert!(
+        tool_names.contains(&"send_email"),
+        "Missing send_email in {:?}",
+        tool_names
+    );
 }

--- a/tests/mcp_integration_test.rs
+++ b/tests/mcp_integration_test.rs
@@ -40,6 +40,9 @@ impl McpTestClient {
                 .read_line(&mut line)
                 .expect("Failed to read from stdout");
             if bytes == 0 {
+                if let Ok(Some(status)) = self.child.try_wait() {
+                    panic!("Proxy process exited unexpectedly with status: {}", status);
+                }
                 if start.elapsed() > READ_TIMEOUT {
                     panic!("Timeout after {:?} waiting for MCP response", READ_TIMEOUT);
                 }

--- a/tests/mcp_integration_test.rs
+++ b/tests/mcp_integration_test.rs
@@ -68,6 +68,7 @@ impl Drop for McpTestClient {
 }
 
 #[test]
+#[ignore = "Live MCP proxy test: requires network and credentials. Run with `cargo test -- --ignored`."]
 fn test_mcp_handshake() {
     let mut client = McpTestClient::spawn();
 

--- a/tests/mcp_integration_test.rs
+++ b/tests/mcp_integration_test.rs
@@ -1,0 +1,94 @@
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, Command, Stdio};
+use serde_json::{json, Value};
+
+struct McpTestClient {
+    child: Child,
+}
+
+impl McpTestClient {
+    fn spawn() -> Self {
+        let child = Command::new("cargo")
+            .args(["run", "--", "proxy"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("Failed to spawn cargo run -- proxy");
+        Self { child }
+    }
+
+    fn send(&mut self, request: Value) {
+        let stdin = self.child.stdin.as_mut().expect("Failed to open stdin");
+        let line = serde_json::to_string(&request).expect("Failed to serialize request");
+        writeln!(stdin, "{}", line).expect("Failed to write to stdin");
+        stdin.flush().expect("Failed to flush stdin");
+    }
+
+    fn receive(&mut self) -> Value {
+        let stdout = self.child.stdout.as_mut().expect("Failed to open stdout");
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("Failed to read from stdout");
+        serde_json::from_str(&line).expect("Failed to deserialize response")
+    }
+
+    fn kill(mut self) {
+        let _ = self.child.kill();
+    }
+}
+
+#[test]
+fn test_mcp_handshake() {
+    let mut client = McpTestClient::spawn();
+
+    // 1. Initialize
+    client.send(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {
+                "name": "test-client",
+                "version": "1.0.0"
+            }
+        }
+    }));
+
+    let response = client.receive();
+    assert_eq!(response["id"], 1);
+    assert!(response["result"]["protocolVersion"].is_string());
+    assert!(response["result"]["capabilities"]["tools"].is_object());
+
+    // 2. Initialized notification
+    client.send(json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+    }));
+
+    // 3. List tools
+    client.send(json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list"
+    }));
+
+    let response = client.receive();
+    assert_eq!(response["id"], 2);
+    let tools = response["result"]["tools"].as_array().expect("Tools should be an array");
+    assert!(!tools.is_empty(), "Tool list should not be empty");
+
+    // Check for core tools
+    let tool_names: Vec<&str> = tools.iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    
+    println!("Actual tool names: {:?}", tool_names);
+    
+    assert!(tool_names.contains(&"get_emails"), "Missing get_emails in {:?}", tool_names);
+    assert!(tool_names.contains(&"send_email"), "Missing send_email in {:?}", tool_names);
+
+    client.kill();
+}


### PR DESCRIPTION
## Summary
- Add Rust integration test (`tests/mcp_integration_test.rs`) that validates the MCP handshake: initialize, notifications/initialized, and tools/list with assertions on core tools
- Add Node.js LLM evaluation script (`eval/`) that verifies Claude correctly generates tool calls for InboxAPI intents and executes them end-to-end against the live proxy
- Fix pre-existing clippy `needless_range_loop` lint in `src/main.rs`
- Add coding standards to `AGENTS.md` and `GEMINI.md` covering Rust, JavaScript, and MCP protocol pitfalls

## Code review fixes applied
The initial implementation had critical and major issues that have been remediated:
- **Rust test**: `BufReader` stored in struct (was re-created per call causing data loss), `Drop` impl added (was leaking child processes), read timeout added (was hanging forever)
- **Eval script**: Refactored to single persistent `ProxyClient` (was spawning a new process per tool call), added `notifications/initialized` to MCP handshake, replaced `execSync` string interpolation with `execFileSync` args array (shell injection fix), proper line-based stdout parsing, input validation, configurable model via `EVAL_MODEL` env var, validates correct tool name in pass/fail logic

## Test plan
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --tests -- -D warnings` passes (zero warnings)
- [x] `cargo test` passes (255 tests)
- [x] `cargo build` succeeds
- [ ] Run `tests/mcp_integration_test.rs` against live proxy (requires auth)
- [ ] Run `eval/index.js` with `ANTHROPIC_API_KEY` set (requires auth + API key)