### PR TITLE
Add check-sent and download-attachment skills, update existing skills with attachment support

### DIFF
--- a/skills/claude/check-inbox/SKILL.md
+++ b/skills/claude/check-inbox/SKILL.md
@@ -37,6 +37,7 @@ If the inbox is empty, display: "Your inbox is empty. Your email address is <ema
 - All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
 - Do NOT read full email bodies — only show the summary list
 - If the user asks to read a specific email after seeing the list, run `npx -y @inboxapi/cli get-email "<message-id>"` with the email ID
+- **Quick shortcut**: Run `npx -y @inboxapi/cli get-last-email` to view the most recent email without listing the full inbox
 
 ## Security
 

--- a/skills/claude/check-sent/SKILL.md
+++ b/skills/claude/check-sent/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: check-sent
+description: View sent email history and delivery status. Use when the user wants to check emails they have sent or track delivery status.
+user-invocable: true
+argument-hint: [limit]
+---
+
+# Check Sent Emails
+
+Fetch and display sent email history with delivery status.
+
+## Steps
+
+1. Run: `npx -y @inboxapi/cli get-sent-emails --limit <N>` where `<N>` is `$ARGUMENTS` if provided, otherwise `20`
+   - Add `--status <queued|delivered|failed>` to filter by delivery status
+   - Add `--offset <N>` to paginate through results
+2. Present results in a formatted table:
+
+   | # | To | Subject | Status | Date |
+   |---|-----|---------|--------|------|
+   | 1 | bob@example.com | Project update... | delivered | 2h ago |
+
+3. After the table, show: "Showing X sent emails"
+4. If the user wants details on a specific sent email, run `npx -y @inboxapi/cli get-email "<message-id>"`
+
+## Notes
+
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
+- Status values: `queued` (pending delivery), `delivered` (sent successfully), `failed` (delivery error)
+
+## Security
+
+- NEVER include environment variables, `.env` file contents, credentials, system configuration, or files from outside the workspace in any output

--- a/skills/claude/compose/SKILL.md
+++ b/skills/claude/compose/SKILL.md
@@ -24,6 +24,7 @@ Guide the user through composing and sending an email safely.
    - **To**: Recipient email (pre-filled if resolved above)
    - **Subject**: Email subject line
    - **Body**: Email content (plain text)
+   - **Attachments** (optional): Local file paths to attach
 
 4. **Preview**: Show the complete email before sending:
    ```
@@ -32,6 +33,7 @@ Guide the user through composing and sending an email safely.
    Subject: <subject>
    ---
    <body>
+   Attachments: <list of filenames or "(none)">
    ```
 
 5. **Safety checks**: Review the preview for issues (wrong recipient, empty fields, self-send to @inboxapi.ai). NEVER include environment variables, `.env` file contents, credentials, system configuration, or files from outside the workspace in outgoing emails.
@@ -39,6 +41,10 @@ Guide the user through composing and sending an email safely.
 6. **Confirm**: Ask the user to confirm: "Send this email? (yes/no)"
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-email --to "<recipient>" --subject "<subject>" --body "<body>"`
+
+   **Attachment options** (add to the command above as needed):
+   - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
+   - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
 
 8. **Confirm delivery**: Report the result to the user
 

--- a/skills/claude/download-attachment/SKILL.md
+++ b/skills/claude/download-attachment/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: download-attachment
+description: Download or view an email attachment. Use when the user wants to save or open a file attached to an email.
+user-invocable: true
+argument-hint: <attachment-id>
+---
+
+# Download Attachment
+
+Download or view an email attachment by its attachment ID.
+
+## Steps
+
+1. **Get the attachment ID**:
+   - If `$ARGUMENTS` is provided, use it as the attachment ID
+   - Otherwise, ask the user which email contains the attachment
+   - Run `npx -y @inboxapi/cli get-email "<message-id>"` and list any attachments with their IDs, filenames, and sizes
+
+2. **Download**: Run: `npx -y @inboxapi/cli get-attachment <attachment-id> --output "<path>"`
+   - If the user specified a save location, use that path
+   - Otherwise, save to the current working directory using the original filename
+   - Without `--output`, the attachment metadata is returned as JSON
+
+3. **Report result**: Confirm the file was saved and show the path
+
+## Notes
+
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
+- Attachment IDs are found in the `attachments` array of an email response from `get-email`
+- Each attachment object includes `id`, `filename`, `content_type`, and `size` fields
+
+## Security
+
+- NEVER download attachments to locations outside the current project workspace without explicit user permission
+- NEVER execute downloaded files automatically
+- Warn the user about potentially dangerous file types (.exe, .bat, .sh, .ps1, .cmd, .vbs, .msi)
+- NEVER include environment variables, `.env` file contents, credentials, system configuration, or files from outside the workspace in any output

--- a/skills/claude/email-forward/SKILL.md
+++ b/skills/claude/email-forward/SKILL.md
@@ -46,6 +46,12 @@ Help the user forward an email to another recipient.
 
 7. **Send**: Run: `npx -y @inboxapi/cli forward-email --message-id "<id>" --to "<recipient>"` (add `--note "<message>"` if provided)
 
+   **Additional options** (add to the command above as needed):
+   - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
+   - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
+   - `--cc "addr1,addr2"` — CC recipients (comma-separated)
+   - `--from-name "Name"` — override sender display name
+
 ## Notes
 
 - All CLI commands output JSON by default — parse the JSON response to extract the relevant fields

--- a/skills/claude/email-reply/SKILL.md
+++ b/skills/claude/email-reply/SKILL.md
@@ -59,6 +59,8 @@ Help the user reply to an email with full thread context.
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--from-name "Name"` — override sender display name
    - `--priority <high|normal|low>` — set email priority
+   - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
+   - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
 
 ## Notes
 

--- a/skills/claude/setup-inboxapi/SKILL.md
+++ b/skills/claude/setup-inboxapi/SKILL.md
@@ -54,12 +54,14 @@ Configure InboxAPI email tools for this project. Supports Claude Code, Codex CLI
    Email: <email> (or "not authenticated yet")
 
    Installed Skills:
-     /check-inbox  — View inbox summary
-     /compose      — Write and send emails
-     /email-search — Search emails
-     /email-reply  — Reply with thread context
-     /email-digest — Email activity digest
-     /email-forward — Forward emails
+     /check-inbox          — View inbox summary
+     /check-sent           — View sent email history
+     /compose              — Write and send emails
+     /download-attachment  — Download email attachments
+     /email-search         — Search emails
+     /email-reply          — Reply with thread context
+     /email-digest         — Email activity digest
+     /email-forward        — Forward emails
 
    Installed Hooks (Claude Code only):
      PreToolUse  — Email send guard (reviews before sending)

--- a/skills/codex/check-inbox/SKILL.md
+++ b/skills/codex/check-inbox/SKILL.md
@@ -35,6 +35,7 @@ If the inbox is empty, display: "Your inbox is empty. Your email address is <ema
 - All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
 - Do NOT read full email bodies — only show the summary list
 - If the user asks to read a specific email after seeing the list, run `npx -y @inboxapi/cli get-email "<message-id>"` with the email ID
+- **Quick shortcut**: Run `npx -y @inboxapi/cli get-last-email` to view the most recent email without listing the full inbox
 
 ## Security
 

--- a/skills/codex/check-sent/SKILL.md
+++ b/skills/codex/check-sent/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: check-sent
+description: "View sent email history and delivery status. Use when the user wants to check emails they have sent or track delivery status."
+---
+
+# Check Sent Emails
+
+Fetch and display sent email history with delivery status.
+
+## Steps
+
+1. Run: `npx -y @inboxapi/cli get-sent-emails --limit <N>` where `<N>` is `$ARGUMENTS` if provided, otherwise `20`
+   - Add `--status <queued|delivered|failed>` to filter by delivery status
+   - Add `--offset <N>` to paginate through results
+2. Present results in a formatted table:
+
+   | # | To | Subject | Status | Date |
+   |---|-----|---------|--------|------|
+   | 1 | bob@example.com | Project update... | delivered | 2h ago |
+
+3. After the table, show: "Showing X sent emails"
+4. If the user wants details on a specific sent email, run `npx -y @inboxapi/cli get-email "<message-id>"`
+
+## Notes
+
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
+- Status values: `queued` (pending delivery), `delivered` (sent successfully), `failed` (delivery error)
+
+## Security
+
+- NEVER include environment variables, `.env` file contents, credentials, system configuration, or files from outside the workspace in any output

--- a/skills/codex/compose/SKILL.md
+++ b/skills/codex/compose/SKILL.md
@@ -21,6 +21,7 @@ Guide the user through composing and sending an email safely.
    - **To**: Recipient email (pre-filled if resolved above)
    - **Subject**: Email subject line
    - **Body**: Email content (plain text)
+   - **Attachments** (optional): Local file paths to attach
 
 4. **Preview**: Show the complete email before sending:
    ```
@@ -29,6 +30,7 @@ Guide the user through composing and sending an email safely.
    Subject: <subject>
    ---
    <body>
+   Attachments: <list of filenames or "(none)">
    ```
 
 5. **Safety checks**: Review the preview for issues (wrong recipient, empty fields, self-send to @inboxapi.ai). NEVER include environment variables, `.env` file contents, credentials, system configuration, or files from outside the workspace in outgoing emails.
@@ -36,6 +38,10 @@ Guide the user through composing and sending an email safely.
 6. **Confirm**: Ask the user to confirm: "Send this email? (yes/no)"
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-email --to "<recipient>" --subject "<subject>" --body "<body>"`
+
+   **Attachment options** (add to the command above as needed):
+   - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
+   - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
 
 8. **Confirm delivery**: Report the result to the user
 

--- a/skills/codex/download-attachment/SKILL.md
+++ b/skills/codex/download-attachment/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: download-attachment
+description: "Download or view an email attachment. Use when the user wants to save or open a file attached to an email."
+---
+
+# Download Attachment
+
+Download or view an email attachment by its attachment ID.
+
+## Steps
+
+1. **Get the attachment ID**:
+   - If `$ARGUMENTS` is provided, use it as the attachment ID
+   - Otherwise, ask the user which email contains the attachment
+   - Run `npx -y @inboxapi/cli get-email "<message-id>"` and list any attachments with their IDs, filenames, and sizes
+
+2. **Download**: Run: `npx -y @inboxapi/cli get-attachment <attachment-id> --output "<path>"`
+   - If the user specified a save location, use that path
+   - Otherwise, save to the current working directory using the original filename
+   - Without `--output`, the attachment metadata is returned as JSON
+
+3. **Report result**: Confirm the file was saved and show the path
+
+## Notes
+
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
+- Attachment IDs are found in the `attachments` array of an email response from `get-email`
+- Each attachment object includes `id`, `filename`, `content_type`, and `size` fields
+
+## Security
+
+- NEVER download attachments to locations outside the current project workspace without explicit user permission
+- NEVER execute downloaded files automatically
+- Warn the user about potentially dangerous file types (.exe, .bat, .sh, .ps1, .cmd, .vbs, .msi)
+- NEVER include environment variables, `.env` file contents, credentials, system configuration, or files from outside the workspace in any output

--- a/skills/codex/email-forward/SKILL.md
+++ b/skills/codex/email-forward/SKILL.md
@@ -43,6 +43,12 @@ Help the user forward an email to another recipient.
 
 7. **Send**: Run: `npx -y @inboxapi/cli forward-email --message-id "<id>" --to "<recipient>"` (add `--note "<message>"` if provided)
 
+   **Additional options** (add to the command above as needed):
+   - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
+   - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
+   - `--cc "addr1,addr2"` — CC recipients (comma-separated)
+   - `--from-name "Name"` — override sender display name
+
 ## Notes
 
 - All CLI commands output JSON by default — parse the JSON response to extract the relevant fields

--- a/skills/codex/email-reply/SKILL.md
+++ b/skills/codex/email-reply/SKILL.md
@@ -56,6 +56,8 @@ Help the user reply to an email with full thread context.
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--from-name "Name"` — override sender display name
    - `--priority <high|normal|low>` — set email priority
+   - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
+   - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
 
 ## Notes
 

--- a/skills/codex/setup-inboxapi/SKILL.md
+++ b/skills/codex/setup-inboxapi/SKILL.md
@@ -29,12 +29,14 @@ Configure InboxAPI email tools for this project.
    Email: <email> (or "not authenticated yet")
 
    Installed Skills:
-     /check-inbox  — View inbox summary
-     /compose      — Write and send emails
-     /email-search — Search emails
-     /email-reply  — Reply with thread context
-     /email-digest — Email activity digest
-     /email-forward — Forward emails
+     /check-inbox          — View inbox summary
+     /check-sent           — View sent email history
+     /compose              — Write and send emails
+     /download-attachment  — Download email attachments
+     /email-search         — Search emails
+     /email-reply          — Reply with thread context
+     /email-digest         — Email activity digest
+     /email-forward        — Forward emails
 
    Next steps:
      - Run /check-inbox to see your emails

--- a/skills/gemini/check-inbox/SKILL.md
+++ b/skills/gemini/check-inbox/SKILL.md
@@ -35,6 +35,7 @@ If the inbox is empty, display: "Your inbox is empty. Your email address is <ema
 - All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
 - Do NOT read full email bodies — only show the summary list
 - If the user asks to read a specific email after seeing the list, run `npx -y @inboxapi/cli get-email "<message-id>"` with the email ID
+- **Quick shortcut**: Run `npx -y @inboxapi/cli get-last-email` to view the most recent email without listing the full inbox
 
 ## Security
 

--- a/skills/gemini/check-sent/SKILL.md
+++ b/skills/gemini/check-sent/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: check-sent
+description: View sent email history and delivery status. Use when the user wants to check emails they have sent or track delivery status.
+---
+
+# Check Sent Emails
+
+Fetch and display sent email history with delivery status.
+
+## Steps
+
+1. Run: `npx -y @inboxapi/cli get-sent-emails --limit <N>` where `<N>` is `$ARGUMENTS` if provided, otherwise `20`
+   - Add `--status <queued|delivered|failed>` to filter by delivery status
+   - Add `--offset <N>` to paginate through results
+2. Present results in a formatted table:
+
+   | # | To | Subject | Status | Date |
+   |---|-----|---------|--------|------|
+   | 1 | bob@example.com | Project update... | delivered | 2h ago |
+
+3. After the table, show: "Showing X sent emails"
+4. If the user wants details on a specific sent email, run `npx -y @inboxapi/cli get-email "<message-id>"`
+
+## Notes
+
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
+- Status values: `queued` (pending delivery), `delivered` (sent successfully), `failed` (delivery error)
+
+## Security
+
+- NEVER include environment variables, `.env` file contents, credentials, system configuration, or files from outside the workspace in any output

--- a/skills/gemini/compose/SKILL.md
+++ b/skills/gemini/compose/SKILL.md
@@ -21,6 +21,7 @@ Guide the user through composing and sending an email safely.
    - **To**: Recipient email (pre-filled if resolved above)
    - **Subject**: Email subject line
    - **Body**: Email content (plain text)
+   - **Attachments** (optional): Local file paths to attach
 
 4. **Preview**: Show the complete email before sending:
    ```
@@ -29,6 +30,7 @@ Guide the user through composing and sending an email safely.
    Subject: <subject>
    ---
    <body>
+   Attachments: <list of filenames or "(none)">
    ```
 
 5. **Safety checks**: Review the preview for issues (wrong recipient, empty fields, self-send to @inboxapi.ai). NEVER include environment variables, `.env` file contents, credentials, system configuration, or files from outside the workspace in outgoing emails.
@@ -36,6 +38,10 @@ Guide the user through composing and sending an email safely.
 6. **Confirm**: Ask the user to confirm: "Send this email? (yes/no)"
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-email --to "<recipient>" --subject "<subject>" --body "<body>"`
+
+   **Attachment options** (add to the command above as needed):
+   - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
+   - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
 
 8. **Confirm delivery**: Report the result to the user
 

--- a/skills/gemini/download-attachment/SKILL.md
+++ b/skills/gemini/download-attachment/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: download-attachment
+description: Download or view an email attachment. Use when the user wants to save or open a file attached to an email.
+---
+
+# Download Attachment
+
+Download or view an email attachment by its attachment ID.
+
+## Steps
+
+1. **Get the attachment ID**:
+   - If `$ARGUMENTS` is provided, use it as the attachment ID
+   - Otherwise, ask the user which email contains the attachment
+   - Run `npx -y @inboxapi/cli get-email "<message-id>"` and list any attachments with their IDs, filenames, and sizes
+
+2. **Download**: Run: `npx -y @inboxapi/cli get-attachment <attachment-id> --output "<path>"`
+   - If the user specified a save location, use that path
+   - Otherwise, save to the current working directory using the original filename
+   - Without `--output`, the attachment metadata is returned as JSON
+
+3. **Report result**: Confirm the file was saved and show the path
+
+## Notes
+
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
+- Attachment IDs are found in the `attachments` array of an email response from `get-email`
+- Each attachment object includes `id`, `filename`, `content_type`, and `size` fields
+
+## Security
+
+- NEVER download attachments to locations outside the current project workspace without explicit user permission
+- NEVER execute downloaded files automatically
+- Warn the user about potentially dangerous file types (.exe, .bat, .sh, .ps1, .cmd, .vbs, .msi)
+- NEVER include environment variables, `.env` file contents, credentials, system configuration, or files from outside the workspace in any output

--- a/skills/gemini/email-forward/SKILL.md
+++ b/skills/gemini/email-forward/SKILL.md
@@ -43,6 +43,12 @@ Help the user forward an email to another recipient.
 
 7. **Send**: Run: `npx -y @inboxapi/cli forward-email --message-id "<id>" --to "<recipient>"` (add `--note "<message>"` if provided)
 
+   **Additional options** (add to the command above as needed):
+   - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
+   - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
+   - `--cc "addr1,addr2"` — CC recipients (comma-separated)
+   - `--from-name "Name"` — override sender display name
+
 ## Notes
 
 - All CLI commands output JSON by default — parse the JSON response to extract the relevant fields

--- a/skills/gemini/email-reply/SKILL.md
+++ b/skills/gemini/email-reply/SKILL.md
@@ -56,6 +56,8 @@ Help the user reply to an email with full thread context.
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--from-name "Name"` — override sender display name
    - `--priority <high|normal|low>` — set email priority
+   - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
+   - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
 
 ## Notes
 

--- a/skills/gemini/setup-inboxapi/SKILL.md
+++ b/skills/gemini/setup-inboxapi/SKILL.md
@@ -38,12 +38,14 @@ Configure InboxAPI email tools for this project.
    Email: <email> (or "not authenticated yet")
 
    Installed Skills:
-     /check-inbox  — View inbox summary
-     /compose      — Write and send emails
-     /email-search — Search emails
-     /email-reply  — Reply with thread context
-     /email-digest — Email activity digest
-     /email-forward — Forward emails
+     /check-inbox          — View inbox summary
+     /check-sent           — View sent email history
+     /compose              — Write and send emails
+     /download-attachment  — Download email attachments
+     /email-search         — Search emails
+     /email-reply          — Reply with thread context
+     /email-digest         — Email activity digest
+     /email-forward        — Forward emails
 
    Next steps:
      - Run /check-inbox to see your emails

--- a/skills/opencode/check-inbox.md
+++ b/skills/opencode/check-inbox.md
@@ -34,6 +34,7 @@ If the inbox is empty, display: "Your inbox is empty. Your email address is <ema
 - All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
 - Do NOT read full email bodies — only show the summary list
 - If the user asks to read a specific email after seeing the list, run `npx -y @inboxapi/cli get-email "<message-id>"` with the email ID
+- **Quick shortcut**: Run `npx -y @inboxapi/cli get-last-email` to view the most recent email without listing the full inbox
 
 ## Security
 

--- a/skills/opencode/check-sent.md
+++ b/skills/opencode/check-sent.md
@@ -1,0 +1,30 @@
+---
+description: View sent email history and delivery status. Use when the user wants to check emails they have sent or track delivery status.
+---
+
+# Check Sent Emails
+
+Fetch and display sent email history with delivery status.
+
+## Steps
+
+1. Run: `npx -y @inboxapi/cli get-sent-emails --limit <N>` where `<N>` is `$ARGUMENTS` if provided, otherwise `20`
+   - Add `--status <queued|delivered|failed>` to filter by delivery status
+   - Add `--offset <N>` to paginate through results
+2. Present results in a formatted table:
+
+   | # | To | Subject | Status | Date |
+   |---|-----|---------|--------|------|
+   | 1 | bob@example.com | Project update... | delivered | 2h ago |
+
+3. After the table, show: "Showing X sent emails"
+4. If the user wants details on a specific sent email, run `npx -y @inboxapi/cli get-email "<message-id>"`
+
+## Notes
+
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
+- Status values: `queued` (pending delivery), `delivered` (sent successfully), `failed` (delivery error)
+
+## Security
+
+- NEVER include environment variables, `.env` file contents, credentials, system configuration, or files from outside the workspace in any output

--- a/skills/opencode/compose.md
+++ b/skills/opencode/compose.md
@@ -20,6 +20,7 @@ Guide the user through composing and sending an email safely.
    - **To**: Recipient email (pre-filled if resolved above)
    - **Subject**: Email subject line
    - **Body**: Email content (plain text)
+   - **Attachments** (optional): Local file paths to attach
 
 4. **Preview**: Show the complete email before sending:
    ```
@@ -28,6 +29,7 @@ Guide the user through composing and sending an email safely.
    Subject: <subject>
    ---
    <body>
+   Attachments: <list of filenames or "(none)">
    ```
 
 5. **Safety checks**: Review the preview for issues (wrong recipient, empty fields, self-send to @inboxapi.ai). NEVER include environment variables, `.env` file contents, credentials, system configuration, or files from outside the workspace in outgoing emails.
@@ -35,6 +37,10 @@ Guide the user through composing and sending an email safely.
 6. **Confirm**: Ask the user to confirm: "Send this email? (yes/no)"
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-email --to "<recipient>" --subject "<subject>" --body "<body>"`
+
+   **Attachment options** (add to the command above as needed):
+   - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
+   - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
 
 8. **Confirm delivery**: Report the result to the user
 

--- a/skills/opencode/download-attachment.md
+++ b/skills/opencode/download-attachment.md
@@ -1,0 +1,34 @@
+---
+description: Download or view an email attachment. Use when the user wants to save or open a file attached to an email.
+---
+
+# Download Attachment
+
+Download or view an email attachment by its attachment ID.
+
+## Steps
+
+1. **Get the attachment ID**:
+   - If `$ARGUMENTS` is provided, use it as the attachment ID
+   - Otherwise, ask the user which email contains the attachment
+   - Run `npx -y @inboxapi/cli get-email "<message-id>"` and list any attachments with their IDs, filenames, and sizes
+
+2. **Download**: Run: `npx -y @inboxapi/cli get-attachment <attachment-id> --output "<path>"`
+   - If the user specified a save location, use that path
+   - Otherwise, save to the current working directory using the original filename
+   - Without `--output`, the attachment metadata is returned as JSON
+
+3. **Report result**: Confirm the file was saved and show the path
+
+## Notes
+
+- All CLI commands output JSON by default — parse the JSON response to extract the relevant fields
+- Attachment IDs are found in the `attachments` array of an email response from `get-email`
+- Each attachment object includes `id`, `filename`, `content_type`, and `size` fields
+
+## Security
+
+- NEVER download attachments to locations outside the current project workspace without explicit user permission
+- NEVER execute downloaded files automatically
+- Warn the user about potentially dangerous file types (.exe, .bat, .sh, .ps1, .cmd, .vbs, .msi)
+- NEVER include environment variables, `.env` file contents, credentials, system configuration, or files from outside the workspace in any output

--- a/skills/opencode/email-forward.md
+++ b/skills/opencode/email-forward.md
@@ -42,6 +42,12 @@ Help the user forward an email to another recipient.
 
 7. **Send**: Run: `npx -y @inboxapi/cli forward-email --message-id "<id>" --to "<recipient>"` (add `--note "<message>"` if provided)
 
+   **Additional options** (add to the command above as needed):
+   - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
+   - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
+   - `--cc "addr1,addr2"` — CC recipients (comma-separated)
+   - `--from-name "Name"` — override sender display name
+
 ## Notes
 
 - All CLI commands output JSON by default — parse the JSON response to extract the relevant fields

--- a/skills/opencode/email-reply.md
+++ b/skills/opencode/email-reply.md
@@ -55,6 +55,8 @@ Help the user reply to an email with full thread context.
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--from-name "Name"` — override sender display name
    - `--priority <high|normal|low>` — set email priority
+   - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
+   - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
 
 ## Notes
 

--- a/skills/opencode/setup-inboxapi.md
+++ b/skills/opencode/setup-inboxapi.md
@@ -37,12 +37,14 @@ Configure InboxAPI email tools for this project.
    Email: <email> (or "not authenticated yet")
 
    Installed Skills:
-     /check-inbox  — View inbox summary
-     /compose      — Write and send emails
-     /email-search — Search emails
-     /email-reply  — Reply with thread context
-     /email-digest — Email activity digest
-     /email-forward — Forward emails
+     /check-inbox          — View inbox summary
+     /check-sent           — View sent email history
+     /compose              — Write and send emails
+     /download-attachment  — Download email attachments
+     /email-search         — Search emails
+     /email-reply          — Reply with thread context
+     /email-digest         — Email activity digest
+     /email-forward        — Forward emails
 
    Next steps:
      - Run /check-inbox to see your emails

--- a/src/main.rs
+++ b/src/main.rs
@@ -639,6 +639,10 @@ static SKILLS: &[(&str, &str)] = &[
         "check-inbox",
         include_str!("../skills/claude/check-inbox/SKILL.md"),
     ),
+    (
+        "check-sent",
+        include_str!("../skills/claude/check-sent/SKILL.md"),
+    ),
     ("compose", include_str!("../skills/claude/compose/SKILL.md")),
     (
         "email-search",
@@ -647,6 +651,10 @@ static SKILLS: &[(&str, &str)] = &[
     (
         "email-reply",
         include_str!("../skills/claude/email-reply/SKILL.md"),
+    ),
+    (
+        "download-attachment",
+        include_str!("../skills/claude/download-attachment/SKILL.md"),
     ),
     (
         "email-digest",
@@ -667,6 +675,10 @@ static CODEX_SKILLS: &[(&str, &str)] = &[
         "check-inbox",
         include_str!("../skills/codex/check-inbox/SKILL.md"),
     ),
+    (
+        "check-sent",
+        include_str!("../skills/codex/check-sent/SKILL.md"),
+    ),
     ("compose", include_str!("../skills/codex/compose/SKILL.md")),
     (
         "email-search",
@@ -675,6 +687,10 @@ static CODEX_SKILLS: &[(&str, &str)] = &[
     (
         "email-reply",
         include_str!("../skills/codex/email-reply/SKILL.md"),
+    ),
+    (
+        "download-attachment",
+        include_str!("../skills/codex/download-attachment/SKILL.md"),
     ),
     (
         "email-digest",
@@ -695,6 +711,10 @@ static GEMINI_SKILLS: &[(&str, &str)] = &[
         "check-inbox",
         include_str!("../skills/gemini/check-inbox/SKILL.md"),
     ),
+    (
+        "check-sent",
+        include_str!("../skills/gemini/check-sent/SKILL.md"),
+    ),
     ("compose", include_str!("../skills/gemini/compose/SKILL.md")),
     (
         "email-search",
@@ -703,6 +723,10 @@ static GEMINI_SKILLS: &[(&str, &str)] = &[
     (
         "email-reply",
         include_str!("../skills/gemini/email-reply/SKILL.md"),
+    ),
+    (
+        "download-attachment",
+        include_str!("../skills/gemini/download-attachment/SKILL.md"),
     ),
     (
         "email-digest",
@@ -723,6 +747,10 @@ static OPENCODE_COMMANDS: &[(&str, &str)] = &[
         "check-inbox",
         include_str!("../skills/opencode/check-inbox.md"),
     ),
+    (
+        "check-sent",
+        include_str!("../skills/opencode/check-sent.md"),
+    ),
     ("compose", include_str!("../skills/opencode/compose.md")),
     (
         "email-search",
@@ -731,6 +759,10 @@ static OPENCODE_COMMANDS: &[(&str, &str)] = &[
     (
         "email-reply",
         include_str!("../skills/opencode/email-reply.md"),
+    ),
+    (
+        "download-attachment",
+        include_str!("../skills/opencode/download-attachment.md"),
     ),
     (
         "email-digest",


### PR DESCRIPTION
## Summary

- Add **check-sent** skill (all 4 platforms) for viewing sent email history via `get-sent-emails` with status/limit/offset filtering
- Add **download-attachment** skill (all 4 platforms) for downloading email attachments via `get-attachment` with output path support
- Update **compose** skill with `--attachment` and `--attachment-ref` flags for file attachments
- Update **email-reply** skill with `--attachment` and `--attachment-ref` flags
- Update **email-forward** skill with `--attachment`, `--attachment-ref`, `--cc`, and `--from-name` flags
- Update **check-inbox** skill with `get-last-email` quick shortcut
- Update **setup-inboxapi** skill to list new skills in the installed skills summary
- Add `include_str!()` entries for new skills in `src/main.rs` (all 4 static arrays)

## Test plan

- [x] `cargo fmt` — no formatting changes needed
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — all 257 tests pass (including `embedded_skill_names_match_across_agents` and `embedded_skill_arrays_have_same_length`)
- [x] `cargo build` — clean compilation