### PR TITLE
feat(cli): add file-backed email bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,15 +19,19 @@ cargo run -- restore <folder>  # Restore credentials from backup
 cargo run -- send-email --to user@example.com --subject "Hi" --body "Hello"
 cargo run -- send-email --to user@example.com --subject "Report" --body "Attached" --attachment ./report.pdf
 cargo run -- send-email --to user@example.com --subject "Fwd" --body "See attached" --attachment-ref UUID
+cargo run -- send-email --to user@example.com --subject "Newsletter" --body-file ./body.txt --html-body-file ./newsletter.html
 cargo run -- get-emails --limit 5
 cargo run -- get-emails --limit 5 --human
 cargo run -- get-email "<message-id>"
 cargo run -- search-emails --subject "invoice"
 cargo run -- get-attachment abc123 --output ./file.pdf
 cargo run -- send-reply --message-id "<id>" --body "Thanks!"
+cargo run -- send-reply --message-id "<id>" --body-file ./reply.txt --html-body-file ./reply.html
 cargo run -- forward-email --message-id "<id>" --to recipient@example.com
 cargo run -- help
 ```
+
+Prefer `--body-file` and `--html-body-file` for complex HTML, templates, or large generated content. The CLI validates file-backed bodies as UTF-8 text, normalizes line endings to `\n`, and caps them at 20 MiB.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,12 @@ Rust-based STDIO proxy that bridges JSON-RPC (MCP protocol) over STDIO to the re
 - `cargo run -- backup <folder>` — back up credentials to a folder
 - `cargo run -- restore <folder>` — restore credentials from a backup folder
 - `cargo run -- send-email --to user@example.com --subject "Hi" --body "Hello"` — send an email
+- `cargo run -- send-email --to user@example.com --subject "Newsletter" --body-file ./body.txt --html-body-file ./newsletter.html` — send a file-backed text + HTML email
 - `cargo run -- get-emails --limit 5` — list inbox emails
 - `cargo run -- get-email "<message-id>"` — get a single email
 - `cargo run -- search-emails --subject "keyword"` — search emails
 - `cargo run -- get-attachment <id> --output ./file.pdf` — download an attachment
-- `cargo run -- send-reply --message-id "<id>" --body "Reply"` — reply to an email (optional: `--cc`, `--bcc`, `--reply-all`, `--html-body`, `--from-name`, `--priority`)
+- `cargo run -- send-reply --message-id "<id>" --body "Reply"` — reply to an email (optional: `--body-file`, `--cc`, `--bcc`, `--reply-all`, `--html-body`, `--html-body-file`, `--from-name`, `--priority`)
 - `cargo run -- forward-email --message-id "<id>" --to user@example.com` — forward an email
 - `cargo run -- get-last-email` — get the most recent email
 - `cargo run -- get-email-count` — get inbox email count (optional `--since`)
@@ -33,6 +34,8 @@ Rust-based STDIO proxy that bridges JSON-RPC (MCP protocol) over STDIO to the re
 - `cargo run -- enable-encryption` — enable email encryption
 - `cargo run -- reset-encryption` — reset email encryption
 - `cargo run -- rotate-encryption --old-secret "x" --new-secret "y"` — rotate encryption secret
+
+For complex HTML, templates, or large generated content, prefer `--body-file` and `--html-body-file`. File-backed bodies are validated as UTF-8 text, normalized to `\n`, and capped at 20 MiB.
 - `cargo run -- setup-skills` — install skills for detected AI agents (interactive)
 - `cargo run -- setup-skills --all` — install skills for all agents (Claude, Codex, Gemini, OpenCode)
 - `cargo run -- setup-skills --claude --codex` — install for specific agents

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,14 +21,18 @@ cargo run -- whoami  # Show current account
 
 # CLI subcommands
 cargo run -- send-email --to user@example.com --subject "Hi" --body "Hello"
+cargo run -- send-email --to user@example.com --subject "Newsletter" --body-file ./body.txt --html-body-file ./newsletter.html
 cargo run -- get-emails --limit 5
 cargo run -- get-email "<message-id>"
 cargo run -- search-emails --subject "keyword"
 cargo run -- get-attachment <id> --output ./file.pdf
 cargo run -- send-reply --message-id "<id>" --body "Reply"
+cargo run -- send-reply --message-id "<id>" --body-file ./reply.txt --html-body-file ./reply.html
 cargo run -- forward-email --message-id "<id>" --to user@example.com
 cargo run -- help
 ```
+
+Prefer `--body-file` and `--html-body-file` for complex HTML, templates, or large generated content. File-backed bodies are validated as UTF-8 text, normalized to `\n`, and capped at 20 MiB.
 
 ## Development Workflow
 - Single Rust source file (`src/main.rs`) containing all proxy, auth, and CLI logic

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The CLI acts as a local bridge between your AI client and the [InboxAPI](https:/
 - **Weekly send limit** — Each account can send to up to five unique email addresses per week. This resets weekly.
 - **Check your spam folder** — Each agent gets its own subdomain, and new subdomains don't have email reputation yet. Early messages may land in your recipient's spam or junk folder. Adding your agent's email address to your contacts or allowlist helps. Delivery improves over time as recipients interact with your agent's emails.
 - **Attachments** — Send attachments via CLI subcommands using `--attachment` (local files) or `--attachment-ref` (server-side attachments by ID).
-- **No rich text yet** — Emails are sent as plain text only. Rich text (HTML) support is coming soon.
+- **HTML email support** — CLI subcommands support HTML emails with `--html-body` or `--html-body-file`.
 - **Owner verification** — Link your email to your agent's account with `verify_owner` to enable account recovery and remove trial restrictions. Recommended as a first step after setup.
 
 ## Installation
@@ -167,9 +167,13 @@ inboxapi send-email --to user@example.com --subject "Hello" --body "Hi there"
 inboxapi send-email --to user@example.com --subject "Report" --body "See attached" --attachment ./report.pdf
 inboxapi send-email --to user@example.com --subject "Fwd" --body "See attached" --attachment-ref 9f0206bb-...
 inboxapi send-email --to "a@b.com, c@d.com" --subject "Hi" --body "Hello" --cc "cc@b.com" --priority high
+inboxapi send-email --to user@example.com --subject "Newsletter" --body-file ./body.txt --html-body-file ./newsletter.html
+inboxapi send-email --to user@example.com --subject "Screenshot" --body-file ./body.txt --html-body-file ./email-with-inline-image.html
 ```
 
-Supports `--cc`, `--bcc`, `--html-body`, `--from-name`, `--priority`, `--attachment` (local files, repeatable), and `--attachment-ref` (server-side attachment IDs, repeatable).
+Supports `--body` or `--body-file`, `--html-body` or `--html-body-file`, `--cc`, `--bcc`, `--from-name`, `--priority`, `--attachment` (local files, repeatable), and `--attachment-ref` (server-side attachment IDs, repeatable).
+
+Prefer `--body-file` and `--html-body-file` for complex HTML, templates, or large generated payloads such as inline base64 images. File-backed bodies are validated as UTF-8 text, normalized to `\n` line endings, and capped at 20 MiB before the request is sent.
 
 ### `get-emails`
 
@@ -201,6 +205,7 @@ inboxapi get-attachment abc123 --output ./file.pdf  # downloads to file
 
 ```bash
 inboxapi send-reply --message-id "<msg-id>" --body "Thanks!"
+inboxapi send-reply --message-id "<msg-id>" --body-file ./reply.txt --html-body-file ./reply.html
 ```
 
 ### `forward-email`
@@ -410,7 +415,7 @@ Yes. Attachment support is fully available. Supply an array of `EmailAttachment`
 
 ### Can I send HTML emails?
 
-HTML email support is coming soon. Currently emails are sent as plain text.
+Yes. Use `--html-body "<html>"` for inline HTML or `--html-body-file ./email.html` for file-backed HTML content. For more complex templates or large generated payloads, prefer `--body-file` and `--html-body-file`.
 
 ### How do credentials work?
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -18,10 +18,13 @@ Agents with shell access can also use CLI subcommands directly — no MCP or JSO
 
 ```
 inboxapi send-email --to user@example.com --subject "Hello" --body "Hi there"
+inboxapi send-email --to user@example.com --subject "Newsletter" --body-file ./body.txt --html-body-file ./newsletter.html
 inboxapi get-emails --limit 5 --human
 inboxapi search-emails --subject "invoice"
 inboxapi help
 ```
+
+Use `--body-file` and `--html-body-file` for complex HTML, templates, or large generated content. File-backed bodies are normalized to `\n` line endings and capped at 20 MiB.
 
 Run `inboxapi help` for the full list of CLI commands and examples.
 

--- a/skills/claude/compose/SKILL.md
+++ b/skills/claude/compose/SKILL.md
@@ -41,6 +41,7 @@ Guide the user through composing and sending an email safely.
 6. **Confirm**: Ask the user to confirm: "Send this email? (yes/no)"
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-email --to "<recipient>" --subject "<subject>" --body "<body>"`
+   If the email body or HTML is complex, prefer `--body-file "<path>"` and `--html-body-file "<path>"` over generating helper scripts just to pass content on the command line. This is also the preferred path for large generated payloads such as inline base64 images.
 
    **Attachment options** (add to the command above as needed):
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)

--- a/skills/claude/email-reply/SKILL.md
+++ b/skills/claude/email-reply/SKILL.md
@@ -46,6 +46,7 @@ Help the user reply to an email with full thread context.
 6. **Confirm**: Ask "Send this reply? (yes/no)"
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
+   If the reply body or HTML is complex, prefer `--body-file "<path>"` and `--html-body-file "<path>"` over generating helper scripts just to pass content on the command line. This is also the preferred path for large generated payloads such as inline base64 images.
 
    **Preserving CC recipients in threads**: If the thread has CC'd recipients, include them with `--cc`:
    ```
@@ -57,6 +58,8 @@ Help the user reply to an email with full thread context.
    - `--bcc "addr1,addr2"` — BCC recipients (comma-separated, silent copy)
    - `--reply-all` — reply to all recipients in the thread
    - `--html-body "<html>"` — send HTML-formatted reply
+   - `--body-file "<path>"` — read the plain-text reply body from a file
+   - `--html-body-file "<path>"` — read the HTML reply body from a file
    - `--from-name "Name"` — override sender display name
    - `--priority <high|normal|low>` — set email priority
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)

--- a/skills/codex/compose/SKILL.md
+++ b/skills/codex/compose/SKILL.md
@@ -38,6 +38,7 @@ Guide the user through composing and sending an email safely.
 6. **Confirm**: Ask the user to confirm: "Send this email? (yes/no)"
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-email --to "<recipient>" --subject "<subject>" --body "<body>"`
+   If the email body or HTML is complex, prefer `--body-file "<path>"` and `--html-body-file "<path>"` over generating helper scripts just to pass content on the command line. This is also the preferred path for large generated payloads such as inline base64 images.
 
    **Attachment options** (add to the command above as needed):
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)

--- a/skills/codex/email-reply/SKILL.md
+++ b/skills/codex/email-reply/SKILL.md
@@ -43,6 +43,7 @@ Help the user reply to an email with full thread context.
 6. **Confirm**: Ask "Send this reply? (yes/no)"
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
+   If the reply body or HTML is complex, prefer `--body-file "<path>"` and `--html-body-file "<path>"` over generating helper scripts just to pass content on the command line. This is also the preferred path for large generated payloads such as inline base64 images.
 
    **Preserving CC recipients in threads**: If the thread has CC'd recipients, include them with `--cc`:
    ```
@@ -54,6 +55,8 @@ Help the user reply to an email with full thread context.
    - `--bcc "addr1,addr2"` — BCC recipients (comma-separated, silent copy)
    - `--reply-all` — reply to all recipients in the thread
    - `--html-body "<html>"` — send HTML-formatted reply
+   - `--body-file "<path>"` — read the plain-text reply body from a file
+   - `--html-body-file "<path>"` — read the HTML reply body from a file
    - `--from-name "Name"` — override sender display name
    - `--priority <high|normal|low>` — set email priority
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)

--- a/skills/gemini/compose/SKILL.md
+++ b/skills/gemini/compose/SKILL.md
@@ -38,6 +38,7 @@ Guide the user through composing and sending an email safely.
 6. **Confirm**: Ask the user to confirm: "Send this email? (yes/no)"
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-email --to "<recipient>" --subject "<subject>" --body "<body>"`
+   If the email body or HTML is complex, prefer `--body-file "<path>"` and `--html-body-file "<path>"` over generating helper scripts just to pass content on the command line. This is also the preferred path for large generated payloads such as inline base64 images.
 
    **Attachment options** (add to the command above as needed):
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)

--- a/skills/gemini/email-reply/SKILL.md
+++ b/skills/gemini/email-reply/SKILL.md
@@ -43,6 +43,7 @@ Help the user reply to an email with full thread context.
 6. **Confirm**: Ask "Send this reply? (yes/no)"
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
+   If the reply body or HTML is complex, prefer `--body-file "<path>"` and `--html-body-file "<path>"` over generating helper scripts just to pass content on the command line. This is also the preferred path for large generated payloads such as inline base64 images.
 
    **Preserving CC recipients in threads**: If the thread has CC'd recipients, include them with `--cc`:
    ```
@@ -54,6 +55,8 @@ Help the user reply to an email with full thread context.
    - `--bcc "addr1,addr2"` — BCC recipients (comma-separated, silent copy)
    - `--reply-all` — reply to all recipients in the thread
    - `--html-body "<html>"` — send HTML-formatted reply
+   - `--body-file "<path>"` — read the plain-text reply body from a file
+   - `--html-body-file "<path>"` — read the HTML reply body from a file
    - `--from-name "Name"` — override sender display name
    - `--priority <high|normal|low>` — set email priority
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)

--- a/skills/opencode/compose.md
+++ b/skills/opencode/compose.md
@@ -37,6 +37,7 @@ Guide the user through composing and sending an email safely.
 6. **Confirm**: Ask the user to confirm: "Send this email? (yes/no)"
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-email --to "<recipient>" --subject "<subject>" --body "<body>"`
+   If the email body or HTML is complex, prefer `--body-file "<path>"` and `--html-body-file "<path>"` over generating helper scripts just to pass content on the command line. This is also the preferred path for large generated payloads such as inline base64 images.
 
    **Attachment options** (add to the command above as needed):
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)

--- a/skills/opencode/email-reply.md
+++ b/skills/opencode/email-reply.md
@@ -42,6 +42,7 @@ Help the user reply to an email with full thread context.
 6. **Confirm**: Ask "Send this reply? (yes/no)"
 
 7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
+   If the reply body or HTML is complex, prefer `--body-file "<path>"` and `--html-body-file "<path>"` over generating helper scripts just to pass content on the command line. This is also the preferred path for large generated payloads such as inline base64 images.
 
    **Preserving CC recipients in threads**: If the thread has CC'd recipients, include them with `--cc`:
    ```
@@ -53,6 +54,8 @@ Help the user reply to an email with full thread context.
    - `--bcc "addr1,addr2"` — BCC recipients (comma-separated, silent copy)
    - `--reply-all` — reply to all recipients in the thread
    - `--html-body "<html>"` — send HTML-formatted reply
+   - `--body-file "<path>"` — read the plain-text reply body from a file
+   - `--html-body-file "<path>"` — read the HTML reply body from a file
    - `--from-name "Name"` — override sender display name
    - `--priority <high|normal|low>` — set email priority
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::cmp::Ordering;
 use std::collections::HashSet;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use tokio::io::{stdin, stdout, AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 /// Maximum size of the SSE buffer (10MB) to prevent memory exhaustion from runaway streams.
 const MAX_SSE_BUFFER_SIZE: usize = 10 * 1024 * 1024;
+/// Maximum size of a body/html body file read from disk (20MiB).
+const MAX_BODY_FILE_BYTES: u64 = 20 * 1024 * 1024;
 
 #[derive(Parser)]
 #[command(name = "inboxapi", bin_name = "inboxapi")]
@@ -90,8 +93,19 @@ enum Commands {
         #[arg(long)]
         subject: String,
         /// Email body (plain text)
-        #[arg(long)]
-        body: String,
+        #[arg(
+            long,
+            required_unless_present = "body_file",
+            conflicts_with = "body_file"
+        )]
+        body: Option<String>,
+        /// Read the plain-text body from a local file
+        #[arg(
+            long = "body-file",
+            required_unless_present = "body",
+            conflicts_with = "body"
+        )]
+        body_file: Option<PathBuf>,
         /// CC recipients, comma-separated
         #[arg(long)]
         cc: Option<String>,
@@ -99,8 +113,11 @@ enum Commands {
         #[arg(long)]
         bcc: Option<String>,
         /// HTML body
-        #[arg(long)]
+        #[arg(long, conflicts_with = "html_body_file")]
         html_body: Option<String>,
+        /// Read the HTML body from a local file
+        #[arg(long = "html-body-file", conflicts_with = "html_body")]
+        html_body_file: Option<PathBuf>,
         /// Sender display name
         #[arg(long)]
         from_name: Option<String>,
@@ -160,8 +177,19 @@ enum Commands {
         #[arg(long)]
         message_id: String,
         /// Reply body (plain text)
-        #[arg(long)]
-        body: String,
+        #[arg(
+            long,
+            required_unless_present = "body_file",
+            conflicts_with = "body_file"
+        )]
+        body: Option<String>,
+        /// Read the plain-text reply body from a local file
+        #[arg(
+            long = "body-file",
+            required_unless_present = "body",
+            conflicts_with = "body"
+        )]
+        body_file: Option<PathBuf>,
         /// CC recipients, comma-separated
         #[arg(long)]
         cc: Option<String>,
@@ -169,8 +197,11 @@ enum Commands {
         #[arg(long)]
         bcc: Option<String>,
         /// HTML body
-        #[arg(long)]
+        #[arg(long, conflicts_with = "html_body_file")]
         html_body: Option<String>,
+        /// Read the HTML body from a local file
+        #[arg(long = "html-body-file", conflicts_with = "html_body")]
+        html_body_file: Option<PathBuf>,
         /// Sender display name
         #[arg(long)]
         from_name: Option<String>,
@@ -1751,6 +1782,81 @@ fn build_send_email_args(
     args
 }
 
+fn resolve_body_input(
+    inline: Option<&str>,
+    file: Option<&Path>,
+    inline_flag: &str,
+    file_flag: &str,
+) -> Result<Option<String>> {
+    match (inline, file) {
+        (Some(_), Some(_)) => Err(anyhow!("Use only one of {} or {}", inline_flag, file_flag)),
+        (Some(value), None) => Ok(Some(value.to_string())),
+        (None, Some(path)) => read_body_file(path, file_flag).map(Some),
+        (None, None) => Ok(None),
+    }
+}
+
+fn read_body_file(path: &Path, file_flag: &str) -> Result<String> {
+    let metadata = std::fs::metadata(path).with_context(|| {
+        format!(
+            "Failed to read metadata for {} {}",
+            file_flag,
+            path.display()
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(anyhow!(
+            "{} path must resolve to a regular file: {}",
+            file_flag,
+            path.display()
+        ));
+    }
+    if metadata.len() > MAX_BODY_FILE_BYTES {
+        return Err(anyhow!(
+            "{} exceeds {} bytes: {}",
+            file_flag,
+            MAX_BODY_FILE_BYTES,
+            path.display()
+        ));
+    }
+
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("Failed to open {} {}", file_flag, path.display()))?;
+    let mut bytes = Vec::with_capacity((metadata.len().min(MAX_BODY_FILE_BYTES)) as usize);
+    file.take(MAX_BODY_FILE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("Failed to read {} {}", file_flag, path.display()))?;
+    if bytes.len() as u64 > MAX_BODY_FILE_BYTES {
+        return Err(anyhow!(
+            "{} exceeds {} bytes: {}",
+            file_flag,
+            MAX_BODY_FILE_BYTES,
+            path.display()
+        ));
+    }
+
+    let text = String::from_utf8(bytes).with_context(|| {
+        format!(
+            "{} must contain valid UTF-8 text: {}",
+            file_flag,
+            path.display()
+        )
+    })?;
+    if text.contains('\0') {
+        return Err(anyhow!(
+            "{} must not contain NUL bytes: {}",
+            file_flag,
+            path.display()
+        ));
+    }
+
+    Ok(normalize_body_newlines(text))
+}
+
+fn normalize_body_newlines(input: String) -> String {
+    input.replace("\r\n", "\n").replace('\r', "\n")
+}
+
 /// Format tool result for human-readable output.
 fn format_human_output(tool_name: &str, text: &str) -> String {
     match tool_name {
@@ -2050,6 +2156,7 @@ Global flags:
 
 Examples:
   inboxapi send-email --to user@example.com --subject \"Hello\" --body \"Hi there\"
+  inboxapi send-email --to user@example.com --subject \"Newsletter\" --body-file ./body.txt --html-body-file ./email.html
   inboxapi send-email --to user@example.com --subject \"Invoice\" --body \"Attached\" --attachment ./invoice.pdf
   inboxapi send-email --to user@example.com --subject \"Fwd\" --body \"See attached\" --attachment-ref 9f0206bb-...
   inboxapi get-emails --limit 5
@@ -2062,6 +2169,7 @@ Examples:
   inboxapi search-emails --subject \"invoice\"
   inboxapi get-attachment abc123 --output ./file.pdf
   inboxapi send-reply --message-id \"<msg-id>\" --body \"Thanks!\"
+  inboxapi send-reply --message-id \"<msg-id>\" --body-file ./reply.txt --html-body-file ./reply.html
   inboxapi forward-email --message-id \"<msg-id>\" --to recipient@example.com
 ";
 
@@ -2116,14 +2224,29 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             ref to,
             ref subject,
             ref body,
+            ref body_file,
             ref cc,
             ref bcc,
             ref html_body,
+            ref html_body_file,
             ref from_name,
             ref priority,
             ref attachments,
             ref attachment_refs,
         }) => {
+            let body = resolve_body_input(
+                body.as_deref(),
+                body_file.as_deref(),
+                "--body",
+                "--body-file",
+            )?
+            .ok_or_else(|| anyhow!("Either --body or --body-file is required"))?;
+            let html_body = resolve_body_input(
+                html_body.as_deref(),
+                html_body_file.as_deref(),
+                "--html-body",
+                "--html-body-file",
+            )?;
             let attachment_entries = process_attachments(
                 attachments,
                 attachment_refs,
@@ -2136,7 +2259,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             let args = build_send_email_args(
                 to,
                 subject,
-                body,
+                &body,
                 cc.as_deref(),
                 bcc.as_deref(),
                 html_body.as_deref(),
@@ -2249,15 +2372,30 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
         Some(Commands::SendReply {
             ref message_id,
             ref body,
+            ref body_file,
             ref cc,
             ref bcc,
             ref html_body,
+            ref html_body_file,
             ref from_name,
             reply_all,
             ref priority,
             ref attachments,
             ref attachment_refs,
         }) => {
+            let body = resolve_body_input(
+                body.as_deref(),
+                body_file.as_deref(),
+                "--body",
+                "--body-file",
+            )?
+            .ok_or_else(|| anyhow!("Either --body or --body-file is required"))?;
+            let html_body = resolve_body_input(
+                html_body.as_deref(),
+                html_body_file.as_deref(),
+                "--html-body",
+                "--html-body-file",
+            )?;
             let attachment_entries = process_attachments(
                 attachments,
                 attachment_refs,
@@ -6719,6 +6857,142 @@ mod tests {
     fn test_split_csv_filters_empty() {
         let result = split_csv("a@b.com,,c@d.com,");
         assert_eq!(result, vec!["a@b.com", "c@d.com"]);
+    }
+
+    // --- resolve_body_input tests ---
+
+    #[test]
+    fn test_resolve_body_input_prefers_inline_value() {
+        let result = resolve_body_input(Some("Hello"), None, "--body", "--body-file").unwrap();
+        assert_eq!(result.as_deref(), Some("Hello"));
+    }
+
+    #[test]
+    fn test_resolve_body_input_reads_file_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("body.html");
+        std::fs::write(&path, "<p>Hello</p>\r\nSecond line\r").unwrap();
+
+        let result =
+            resolve_body_input(None, Some(&path), "--html-body", "--html-body-file").unwrap();
+
+        assert_eq!(result.as_deref(), Some("<p>Hello</p>\nSecond line\n"));
+    }
+
+    #[test]
+    fn test_resolve_body_input_rejects_both_inline_and_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("body.txt");
+        std::fs::write(&path, "Hello").unwrap();
+
+        let err =
+            resolve_body_input(Some("Hello"), Some(&path), "--body", "--body-file").unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("Use only one of --body or --body-file"));
+    }
+
+    #[test]
+    fn test_resolve_body_input_rejects_directory() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let err = resolve_body_input(None, Some(dir.path()), "--body", "--body-file").unwrap_err();
+
+        assert!(err.to_string().contains("regular file"));
+    }
+
+    #[test]
+    fn test_resolve_body_input_rejects_invalid_utf8() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("body.bin");
+        std::fs::write(&path, [0xff, 0xfe, 0xfd]).unwrap();
+
+        let err = resolve_body_input(None, Some(&path), "--body", "--body-file").unwrap_err();
+
+        assert!(err.to_string().contains("valid UTF-8 text"));
+    }
+
+    #[test]
+    fn test_resolve_body_input_rejects_nul_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("body.txt");
+        std::fs::write(&path, b"Hello\0World").unwrap();
+
+        let err = resolve_body_input(None, Some(&path), "--body", "--body-file").unwrap_err();
+
+        assert!(err.to_string().contains("must not contain NUL bytes"));
+    }
+
+    #[test]
+    fn test_resolve_body_input_rejects_oversized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("large.txt");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(MAX_BODY_FILE_BYTES + 1).unwrap();
+
+        let err = resolve_body_input(None, Some(&path), "--body", "--body-file").unwrap_err();
+
+        assert!(err.to_string().contains(&MAX_BODY_FILE_BYTES.to_string()));
+    }
+
+    // --- CLI parsing tests ---
+
+    #[test]
+    fn test_send_email_accepts_body_file_flags() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "send-email",
+            "--to",
+            "user@example.com",
+            "--subject",
+            "Hello",
+            "--body-file",
+            "./body.txt",
+            "--html-body-file",
+            "./email.html",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::SendEmail {
+                body,
+                body_file,
+                html_body,
+                html_body_file,
+                ..
+            }) => {
+                assert!(body.is_none());
+                assert_eq!(body_file, Some(PathBuf::from("./body.txt")));
+                assert!(html_body.is_none());
+                assert_eq!(html_body_file, Some(PathBuf::from("./email.html")));
+            }
+            other => panic!(
+                "expected SendEmail command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_send_reply_rejects_body_and_body_file_together() {
+        let result = Cli::try_parse_from([
+            "inboxapi",
+            "send-reply",
+            "--message-id",
+            "<msg-id>",
+            "--body",
+            "Hello",
+            "--body-file",
+            "./reply.txt",
+        ]);
+
+        assert!(
+            result.is_err(),
+            "parsing should fail when both body flags are set"
+        );
+        let err = result.err().unwrap();
+        assert!(err.to_string().contains("--body-file"));
     }
 
     // --- guess_content_type tests ---


### PR DESCRIPTION
## Summary

Adds file-backed email body support to the CLI so callers can pass complex HTML or large generated payloads without inventing helper scripts.

## What changed

- added `--body-file` and `--html-body-file` to `send-email`
- added `--body-file` and `--html-body-file` to `send-reply`
- validate file-backed bodies before sending:
  - require a regular file
  - enforce valid UTF-8
  - reject NUL bytes
  - cap reads at 20 MiB
  - normalize line endings to `\n`
- updated CLI help, README, agent docs, and compose/reply skills to recommend file-backed bodies for complex HTML and large generated content
- removed stale docs that still claimed HTML email support was "coming soon"

## Why

Agents were generating awkward shell or Python helpers just to get complex HTML into `inboxapi send-email` and `send-reply`. File-backed bodies make that path direct while also hardening the local file boundary against oversized inputs, binary blobs, and special files.

## Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build`
