### PR TITLE
fix: security hardening, robustness, and performance improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,11 @@ jobs:
             fi
           done
 
+      - name: Generate SHA256 checksums
+        run: |
+          cd release-assets
+          sha256sum * > SHA256SUMS
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,15 +713,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,29 +783,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -991,15 +959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,12 +1091,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,16 +1161,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
 
 [[package]]
 name = "slab"
@@ -1377,9 +1320,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ tokio-stream = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.0", features = ["io-util", "io-std", "rt-multi-thread", "macros", "time", "sync", "fs"] }
 sha1 = "0.10"
 chrono = "0.4"
 rand = "0.8"

--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ function findBinary() {
         // prevent symlink-based attacks from a compromised package.
         const realBin = fs.realpathSync(binPath);
         const realPkg = fs.realpathSync(pkgDir);
-        if (realBin.startsWith(realPkg + path.sep)) return realBin;
+        const relative = path.relative(realPkg, realBin);
+        if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)) return realBin;
       }
     } catch {}
   }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,13 @@ function findBinary() {
     try {
       const pkgDir = path.dirname(require.resolve(`${pkg}/package.json`, { paths: [__dirname] }));
       const binPath = path.join(pkgDir, binName);
-      if (fs.existsSync(binPath)) return binPath;
+      if (fs.existsSync(binPath)) {
+        // Validate resolved path is within the expected package directory to
+        // prevent symlink-based attacks from a compromised package.
+        const realBin = fs.realpathSync(binPath);
+        const realPkg = fs.realpathSync(pkgDir);
+        if (realBin.startsWith(realPkg + path.sep)) return realBin;
+      }
     } catch {}
   }
 

--- a/skills/hooks/email-activity-logger.js
+++ b/skills/hooks/email-activity-logger.js
@@ -76,14 +76,15 @@ function main() {
     }
   }
 
-  const logLine = `[${timestamp}] ${shortName}: ${details}\n`;
+  const sanitize = (s) => (s || "").replace(/[\r\n]/g, " ");
+  const logLine = `[${timestamp}] ${sanitize(shortName)}: ${sanitize(details)}\n`;
 
   // Write to log file
   const logPath = path.join(cwd, ".claude", "inboxapi-activity.log");
   try {
     const logDir = path.dirname(logPath);
     if (!fs.existsSync(logDir)) {
-      fs.mkdirSync(logDir, { recursive: true });
+      fs.mkdirSync(logDir, { recursive: true, mode: 0o700 });
     }
     fs.appendFileSync(logPath, logLine);
   } catch {

--- a/skills/hooks/email-activity-logger.js
+++ b/skills/hooks/email-activity-logger.js
@@ -86,7 +86,11 @@ function main() {
     if (!fs.existsSync(logDir)) {
       fs.mkdirSync(logDir, { recursive: true, mode: 0o700 });
     }
-    fs.appendFileSync(logPath, logLine);
+    // Best-effort: ensure directory is user-only accessible even if it already existed
+    try { fs.chmodSync(logDir, 0o700); } catch {}
+    fs.appendFileSync(logPath, logLine, { mode: 0o600 });
+    // Best-effort: harden log file permissions if it already existed
+    try { fs.chmodSync(logPath, 0o600); } catch {}
   } catch {
     // Non-critical — don't fail the tool call
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1465,18 +1465,19 @@ fn drain_sse_events(buf: &mut String) -> Vec<SseEvent> {
         }
 
         if (event_type == "message" || event_type.is_empty()) && !data_lines.is_empty() {
-            let data = data_lines.join("\n");
-            if data.len() > MAX_SSE_EVENT_SIZE {
+            // Check accumulated size before allocating the joined string
+            let estimated_size: usize = data_lines.iter().map(|l| l.len()).sum::<usize>()
+                + data_lines.len().saturating_sub(1); // newline separators
+            if estimated_size > MAX_SSE_EVENT_SIZE {
                 eprintln!(
                     "SSE event data exceeds limit ({} bytes, max {}) - skipping",
-                    data.len(),
-                    MAX_SSE_EVENT_SIZE
+                    estimated_size, MAX_SSE_EVENT_SIZE
                 );
                 continue;
             }
             events.push(SseEvent {
                 _event_type: event_type,
-                data,
+                data: data_lines.join("\n"),
             });
         }
     }
@@ -1506,6 +1507,15 @@ fn drain_sse_remainder(buf: &str) -> Option<SseEvent> {
     }
 
     if (event_type == "message" || event_type.is_empty()) && !data_lines.is_empty() {
+        let estimated_size: usize =
+            data_lines.iter().map(|l| l.len()).sum::<usize>() + data_lines.len().saturating_sub(1);
+        if estimated_size > MAX_SSE_EVENT_SIZE {
+            eprintln!(
+                "SSE remainder event data exceeds limit ({} bytes, max {}) - skipping",
+                estimated_size, MAX_SSE_EVENT_SIZE
+            );
+            return None;
+        }
         Some(SseEvent {
             _event_type: event_type,
             data: data_lines.join("\n"),
@@ -1684,6 +1694,50 @@ fn build_attachment_from_file(path: &str) -> Result<Value> {
 /// Timeout for downloading attachments (used in both resolve_attachment_ref and get-attachment).
 const ATTACHMENT_DOWNLOAD_TIMEOUT_SECS: u64 = 120;
 
+/// Download a URL with a streaming size cap to prevent memory exhaustion.
+/// Returns the downloaded bytes, aborting early if `MAX_ATTACHMENT_DOWNLOAD_BYTES` is exceeded.
+async fn download_with_limit(http_client: &HttpClient, url: &str) -> Result<Vec<u8>> {
+    use tokio_stream::StreamExt as _;
+
+    let resp = http_client
+        .get(url)
+        .timeout(std::time::Duration::from_secs(
+            ATTACHMENT_DOWNLOAD_TIMEOUT_SECS,
+        ))
+        .send()
+        .await
+        .context("Failed to download attachment")?;
+
+    // Fast reject if Content-Length is present and exceeds limit
+    if let Some(content_length) = resp.content_length() {
+        if content_length > MAX_ATTACHMENT_DOWNLOAD_BYTES {
+            return Err(anyhow!(
+                "Attachment too large ({} bytes, max {} bytes)",
+                content_length,
+                MAX_ATTACHMENT_DOWNLOAD_BYTES
+            ));
+        }
+    }
+
+    // Stream the body with a running byte counter
+    let mut stream = resp.bytes_stream();
+    let mut buf = Vec::new();
+    let mut total: u64 = 0;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context("Failed to read attachment chunk")?;
+        total += chunk.len() as u64;
+        if total > MAX_ATTACHMENT_DOWNLOAD_BYTES {
+            return Err(anyhow!(
+                "Attachment too large (>{} bytes, max {} bytes)",
+                total,
+                MAX_ATTACHMENT_DOWNLOAD_BYTES
+            ));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
+}
+
 /// Resolve a server-side attachment ref to an attachment entry.
 async fn resolve_attachment_ref(
     attachment_id: &str,
@@ -1722,35 +1776,8 @@ async fn resolve_attachment_ref(
         })
         .to_string();
 
-    // Download the file
-    let file_resp = http_client
-        .get(url)
-        .timeout(std::time::Duration::from_secs(
-            ATTACHMENT_DOWNLOAD_TIMEOUT_SECS,
-        ))
-        .send()
-        .await
-        .context("Failed to download attachment")?;
-    if let Some(content_length) = file_resp.content_length() {
-        if content_length > MAX_ATTACHMENT_DOWNLOAD_BYTES {
-            return Err(anyhow!(
-                "Attachment too large ({} bytes, max {} bytes)",
-                content_length,
-                MAX_ATTACHMENT_DOWNLOAD_BYTES
-            ));
-        }
-    }
-    let bytes = file_resp
-        .bytes()
-        .await
-        .context("Failed to read attachment bytes")?;
-    if bytes.len() as u64 > MAX_ATTACHMENT_DOWNLOAD_BYTES {
-        return Err(anyhow!(
-            "Attachment too large ({} bytes, max {} bytes)",
-            bytes.len(),
-            MAX_ATTACHMENT_DOWNLOAD_BYTES
-        ));
-    }
+    // Download the file with streaming size cap
+    let bytes = download_with_limit(http_client, url).await?;
     let content = data_encoding::BASE64.encode(&bytes);
 
     Ok(json!({
@@ -1832,7 +1859,23 @@ fn resolve_body_input(
 }
 
 fn read_body_file(path: &Path, file_flag: &str) -> Result<String> {
-    // Open file first, then query metadata on the handle to avoid TOCTOU races
+    // Pre-check: reject non-regular files (FIFOs, dirs, etc.) without blocking on open.
+    let pre_meta = std::fs::symlink_metadata(path).with_context(|| {
+        format!(
+            "Failed to read metadata for {} {}",
+            file_flag,
+            path.display()
+        )
+    })?;
+    if !pre_meta.is_file() {
+        return Err(anyhow!(
+            "{} path must resolve to a regular file: {}",
+            file_flag,
+            path.display()
+        ));
+    }
+
+    // Open the file, then verify metadata on the handle to avoid TOCTOU races.
     let file = std::fs::File::open(path)
         .with_context(|| format!("Failed to open {} {}", file_flag, path.display()))?;
     let metadata = file.metadata().with_context(|| {
@@ -2379,34 +2422,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
                     .as_str()
                     .or_else(|| data["url"].as_str())
                     .ok_or_else(|| anyhow!("No URL in get_attachment response"))?;
-                let file_resp = http_client
-                    .get(url)
-                    .timeout(std::time::Duration::from_secs(
-                        ATTACHMENT_DOWNLOAD_TIMEOUT_SECS,
-                    ))
-                    .send()
-                    .await
-                    .context("Failed to download attachment")?;
-                if let Some(content_length) = file_resp.content_length() {
-                    if content_length > MAX_ATTACHMENT_DOWNLOAD_BYTES {
-                        return Err(anyhow!(
-                            "Attachment too large ({} bytes, max {} bytes)",
-                            content_length,
-                            MAX_ATTACHMENT_DOWNLOAD_BYTES
-                        ));
-                    }
-                }
-                let bytes = file_resp
-                    .bytes()
-                    .await
-                    .context("Failed to read attachment bytes")?;
-                if bytes.len() as u64 > MAX_ATTACHMENT_DOWNLOAD_BYTES {
-                    return Err(anyhow!(
-                        "Attachment too large ({} bytes, max {} bytes)",
-                        bytes.len(),
-                        MAX_ATTACHMENT_DOWNLOAD_BYTES
-                    ));
-                }
+                let bytes = download_with_limit(&http_client, url).await?;
                 std::fs::write(output_path, &bytes)
                     .with_context(|| format!("Failed to write to {}", output_path))?;
                 if cli.human {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,12 @@ use tokio::io::{stdin, stdout, AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 /// Maximum size of the SSE buffer (10MB) to prevent memory exhaustion from runaway streams.
 const MAX_SSE_BUFFER_SIZE: usize = 10 * 1024 * 1024;
+/// Maximum size of a single SSE event data payload (5MB).
+const MAX_SSE_EVENT_SIZE: usize = 5 * 1024 * 1024;
 /// Maximum size of a body/html body file read from disk (20MiB).
 const MAX_BODY_FILE_BYTES: u64 = 20 * 1024 * 1024;
+/// Maximum size of an attachment download (100MB) to prevent memory exhaustion.
+const MAX_ATTACHMENT_DOWNLOAD_BYTES: u64 = 100 * 1024 * 1024;
 
 #[derive(Parser)]
 #[command(name = "inboxapi", bin_name = "inboxapi")]
@@ -512,6 +516,7 @@ fn save_credentials(creds: &Credentials) -> Result<()> {
             .mode(0o600)
             .open(path)?;
         file.write_all(content.as_bytes())?;
+        file.sync_all()?;
     }
 
     #[cfg(not(unix))]
@@ -1460,9 +1465,18 @@ fn drain_sse_events(buf: &mut String) -> Vec<SseEvent> {
         }
 
         if (event_type == "message" || event_type.is_empty()) && !data_lines.is_empty() {
+            let data = data_lines.join("\n");
+            if data.len() > MAX_SSE_EVENT_SIZE {
+                eprintln!(
+                    "SSE event data exceeds limit ({} bytes, max {}) - skipping",
+                    data.len(),
+                    MAX_SSE_EVENT_SIZE
+                );
+                continue;
+            }
             events.push(SseEvent {
                 _event_type: event_type,
-                data: data_lines.join("\n"),
+                data,
             });
         }
     }
@@ -1717,10 +1731,26 @@ async fn resolve_attachment_ref(
         .send()
         .await
         .context("Failed to download attachment")?;
+    if let Some(content_length) = file_resp.content_length() {
+        if content_length > MAX_ATTACHMENT_DOWNLOAD_BYTES {
+            return Err(anyhow!(
+                "Attachment too large ({} bytes, max {} bytes)",
+                content_length,
+                MAX_ATTACHMENT_DOWNLOAD_BYTES
+            ));
+        }
+    }
     let bytes = file_resp
         .bytes()
         .await
         .context("Failed to read attachment bytes")?;
+    if bytes.len() as u64 > MAX_ATTACHMENT_DOWNLOAD_BYTES {
+        return Err(anyhow!(
+            "Attachment too large ({} bytes, max {} bytes)",
+            bytes.len(),
+            MAX_ATTACHMENT_DOWNLOAD_BYTES
+        ));
+    }
     let content = data_encoding::BASE64.encode(&bytes);
 
     Ok(json!({
@@ -1802,7 +1832,10 @@ fn resolve_body_input(
 }
 
 fn read_body_file(path: &Path, file_flag: &str) -> Result<String> {
-    let metadata = std::fs::metadata(path).with_context(|| {
+    // Open file first, then query metadata on the handle to avoid TOCTOU races
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("Failed to open {} {}", file_flag, path.display()))?;
+    let metadata = file.metadata().with_context(|| {
         format!(
             "Failed to read metadata for {} {}",
             file_flag,
@@ -1825,8 +1858,6 @@ fn read_body_file(path: &Path, file_flag: &str) -> Result<String> {
         ));
     }
 
-    let file = std::fs::File::open(path)
-        .with_context(|| format!("Failed to open {} {}", file_flag, path.display()))?;
     let mut bytes = Vec::with_capacity((metadata.len().min(MAX_BODY_FILE_BYTES)) as usize);
     file.take(MAX_BODY_FILE_BYTES + 1)
         .read_to_end(&mut bytes)
@@ -2356,10 +2387,26 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
                     .send()
                     .await
                     .context("Failed to download attachment")?;
+                if let Some(content_length) = file_resp.content_length() {
+                    if content_length > MAX_ATTACHMENT_DOWNLOAD_BYTES {
+                        return Err(anyhow!(
+                            "Attachment too large ({} bytes, max {} bytes)",
+                            content_length,
+                            MAX_ATTACHMENT_DOWNLOAD_BYTES
+                        ));
+                    }
+                }
                 let bytes = file_resp
                     .bytes()
                     .await
                     .context("Failed to read attachment bytes")?;
+                if bytes.len() as u64 > MAX_ATTACHMENT_DOWNLOAD_BYTES {
+                    return Err(anyhow!(
+                        "Attachment too large ({} bytes, max {} bytes)",
+                        bytes.len(),
+                        MAX_ATTACHMENT_DOWNLOAD_BYTES
+                    ));
+                }
                 std::fs::write(output_path, &bytes)
                     .with_context(|| format!("Failed to write to {}", output_path))?;
                 if cli.human {
@@ -3384,13 +3431,37 @@ fn inject_rate_limit_warning(response: &mut Value, retry_after: u64) {
 }
 
 fn is_token_expired_error(response: &Value) -> bool {
+    /// Known auth-failure error codes from the API.
+    const AUTH_ERROR_CODES: &[i64] = &[-32001, -32003];
+
     fn text_matches_token_error(text: &str) -> bool {
         let lower = text.to_lowercase();
-        lower.contains("token")
-            && (lower.contains("expired") || lower.contains("invalid") || lower.contains("revoked"))
+        // Require phrases that unambiguously indicate an auth token issue, not
+        // generic mentions of "token" or "invalid" that could appear in email
+        // bodies or other unrelated error messages.
+        lower.contains("access token expired")
+            || lower.contains("token has expired")
+            || lower.contains("token is expired")
+            || lower.contains("token revoked")
+            || lower.contains("token is invalid")
+            || lower.contains("invalid access token")
+            || lower.contains("invalid refresh token")
+            || lower.contains("authentication failed")
+            || lower.contains("unauthorized")
     }
 
-    // Check JSON-RPC error (server-level auth failure)
+    // Check JSON-RPC error code first (most reliable signal)
+    if let Some(code) = response
+        .get("error")
+        .and_then(|e| e.get("code"))
+        .and_then(|c| c.as_i64())
+    {
+        if AUTH_ERROR_CODES.contains(&code) {
+            return true;
+        }
+    }
+
+    // Check JSON-RPC error message (server-level auth failure)
     if let Some(error_msg) = response
         .get("error")
         .and_then(|e| e.get("message"))
@@ -3434,6 +3505,7 @@ async fn refresh_access_token(
         .post(endpoint)
         .header(CONTENT_TYPE, "application/json")
         .header(ACCEPT, "application/json, text/event-stream")
+        .timeout(std::time::Duration::from_secs(30))
         .json(&json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -5462,25 +5534,63 @@ mod tests {
 
     #[test]
     fn is_token_expired_error_detects_expired_token() {
-        let resp = make_error_response("Token is invalid, expired, or revoked");
+        let resp = make_error_response("Access token expired");
         assert!(is_token_expired_error(&resp));
     }
 
     #[test]
     fn is_token_expired_error_detects_invalid_token() {
-        let resp = make_error_response("Invalid token provided");
+        let resp = make_error_response("Invalid access token");
         assert!(is_token_expired_error(&resp));
     }
 
     #[test]
     fn is_token_expired_error_detects_revoked_token() {
-        let resp = make_error_response("This token has been revoked");
+        let resp = make_error_response("Token revoked");
         assert!(is_token_expired_error(&resp));
     }
 
     #[test]
     fn is_token_expired_error_case_insensitive() {
-        let resp = make_error_response("TOKEN IS EXPIRED");
+        let resp = make_error_response("TOKEN HAS EXPIRED");
+        assert!(is_token_expired_error(&resp));
+    }
+
+    #[test]
+    fn is_token_expired_error_detects_authentication_failed() {
+        let resp = make_error_response("Authentication failed");
+        assert!(is_token_expired_error(&resp));
+    }
+
+    #[test]
+    fn is_token_expired_error_detects_unauthorized() {
+        let resp = make_error_response("Unauthorized");
+        assert!(is_token_expired_error(&resp));
+    }
+
+    #[test]
+    fn is_token_expired_error_detects_auth_error_code() {
+        let resp = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {
+                "code": -32001,
+                "message": "Something went wrong"
+            }
+        });
+        assert!(is_token_expired_error(&resp));
+    }
+
+    #[test]
+    fn is_token_expired_error_detects_auth_error_code_32003() {
+        let resp = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {
+                "code": -32003,
+                "message": "Forbidden"
+            }
+        });
         assert!(is_token_expired_error(&resp));
     }
 
@@ -5503,12 +5613,19 @@ mod tests {
     }
 
     #[test]
+    fn is_token_expired_error_rejects_generic_token_mention() {
+        // Should not trigger on email content that happens to mention "token" and "invalid"
+        let resp = make_error_response("The token field in the form is invalid");
+        assert!(!is_token_expired_error(&resp));
+    }
+
+    #[test]
     fn is_token_expired_error_handles_missing_is_error() {
         let resp = json!({
             "jsonrpc": "2.0",
             "id": 1,
             "result": {
-                "content": [{"type": "text", "text": "Token expired"}]
+                "content": [{"type": "text", "text": "Token has expired"}]
             }
         });
         assert!(!is_token_expired_error(&resp));


### PR DESCRIPTION
## Summary

- **TOCTOU race fix**: `read_body_file()` now opens the file first, then queries metadata on the open handle instead of checking metadata separately
- **Attachment download size limit**: Added 100MB cap with `Content-Length` pre-check and post-download validation in both proxy and CLI paths
- **Credential fsync**: Added `file.sync_all()` after writing credentials to prevent corruption on crash
- **Tighter token expiry detection**: Replaced loose substring matching with specific auth-failure phrases and JSON-RPC error code matching (`-32001`/`-32003`) to eliminate false positives
- **SSE per-event size limit**: Added 5MB limit on individual SSE event payloads in `drain_sse_events()`
- **Token refresh timeout**: Added 30-second timeout to `refresh_access_token()` HTTP call
- **Binary path validation**: `index.js` now validates resolved binary with `realpathSync()` to prevent symlink attacks
- **Log hardening**: Activity logger creates `.claude/` with mode `0o700` and sanitizes log entries against injection
- **Release checksums**: Added SHA256SUMS generation to GitHub Release workflow
- **Tokio feature trimming**: Replaced `features = ["full"]` with only the 6 features actually used

## Test plan

- [x] `cargo fmt` — no formatting changes needed
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — all 271 tests pass (including new token expiry detection tests)
- [x] `cargo build` — clean compilation
- [ ] Manual: `cargo run -- proxy` starts without errors
- [ ] Manual: verify credential write with a login flow