### PR TITLE
br-pq0: bump CLI to v0.3.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "inboxapi-cli"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inboxapi-cli"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inboxapi/cli",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "📧 Email for your AI 🤖",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump Cargo and npm package metadata to 0.3.13 before tagging the CLI release

## Tests
- cargo metadata --no-deps --format-version 1
- cargo test