### PR TITLE
Stop advertising mutable sender names

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ inboxapi send-email --to user@example.com --subject "Newsletter" --body-file ./b
 inboxapi send-email --to user@example.com --subject "Screenshot" --body-file ./body.txt --html-body-file ./email-with-inline-image.html
 ```
 
-Supports `--body` or `--body-file`, `--html-body` or `--html-body-file`, `--cc`, `--bcc`, `--from-name`, `--priority`, `--attachment` (local files, repeatable), and `--attachment-ref` (server-side attachment IDs, repeatable).
+Supports `--body` or `--body-file`, `--html-body` or `--html-body-file`, `--cc`, `--bcc`, `--priority`, `--attachment` (local files, repeatable), and `--attachment-ref` (server-side attachment IDs, repeatable). `--from-name` is deprecated and ignored; InboxAPI enforces the authenticated account identity.
 
 Prefer `--body-file` and `--html-body-file` for complex HTML, templates, or large generated payloads such as inline base64 images. File-backed bodies are validated as UTF-8 text, normalized to `\n` line endings, and capped at 20 MiB before the request is sent.
 

--- a/skills/claude/email-forward/SKILL.md
+++ b/skills/claude/email-forward/SKILL.md
@@ -50,7 +50,6 @@ Help the user forward an email to another recipient.
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
    - `--cc "addr1,addr2"` — CC recipients (comma-separated)
-   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
 
 ## Notes
 

--- a/skills/claude/email-forward/SKILL.md
+++ b/skills/claude/email-forward/SKILL.md
@@ -50,7 +50,7 @@ Help the user forward an email to another recipient.
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
    - `--cc "addr1,addr2"` — CC recipients (comma-separated)
-   - `--from-name "Name"` — override sender display name
+   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
 
 ## Notes
 

--- a/skills/claude/email-reply/SKILL.md
+++ b/skills/claude/email-reply/SKILL.md
@@ -60,7 +60,6 @@ Help the user reply to an email with full thread context.
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--body-file "<path>"` — read the plain-text reply body from a file
    - `--html-body-file "<path>"` — read the HTML reply body from a file
-   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
    - `--priority <high|normal|low>` — set email priority
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)

--- a/skills/claude/email-reply/SKILL.md
+++ b/skills/claude/email-reply/SKILL.md
@@ -60,7 +60,7 @@ Help the user reply to an email with full thread context.
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--body-file "<path>"` — read the plain-text reply body from a file
    - `--html-body-file "<path>"` — read the HTML reply body from a file
-   - `--from-name "Name"` — override sender display name
+   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
    - `--priority <high|normal|low>` — set email priority
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)

--- a/skills/codex/email-forward/SKILL.md
+++ b/skills/codex/email-forward/SKILL.md
@@ -47,7 +47,6 @@ Help the user forward an email to another recipient.
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
    - `--cc "addr1,addr2"` — CC recipients (comma-separated)
-   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
 
 ## Notes
 

--- a/skills/codex/email-forward/SKILL.md
+++ b/skills/codex/email-forward/SKILL.md
@@ -47,7 +47,7 @@ Help the user forward an email to another recipient.
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
    - `--cc "addr1,addr2"` — CC recipients (comma-separated)
-   - `--from-name "Name"` — override sender display name
+   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
 
 ## Notes
 

--- a/skills/codex/email-reply/SKILL.md
+++ b/skills/codex/email-reply/SKILL.md
@@ -57,7 +57,7 @@ Help the user reply to an email with full thread context.
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--body-file "<path>"` — read the plain-text reply body from a file
    - `--html-body-file "<path>"` — read the HTML reply body from a file
-   - `--from-name "Name"` — override sender display name
+   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
    - `--priority <high|normal|low>` — set email priority
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)

--- a/skills/codex/email-reply/SKILL.md
+++ b/skills/codex/email-reply/SKILL.md
@@ -57,7 +57,6 @@ Help the user reply to an email with full thread context.
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--body-file "<path>"` — read the plain-text reply body from a file
    - `--html-body-file "<path>"` — read the HTML reply body from a file
-   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
    - `--priority <high|normal|low>` — set email priority
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)

--- a/skills/gemini/email-forward/SKILL.md
+++ b/skills/gemini/email-forward/SKILL.md
@@ -47,7 +47,6 @@ Help the user forward an email to another recipient.
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
    - `--cc "addr1,addr2"` — CC recipients (comma-separated)
-   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
 
 ## Notes
 

--- a/skills/gemini/email-forward/SKILL.md
+++ b/skills/gemini/email-forward/SKILL.md
@@ -47,7 +47,7 @@ Help the user forward an email to another recipient.
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
    - `--cc "addr1,addr2"` — CC recipients (comma-separated)
-   - `--from-name "Name"` — override sender display name
+   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
 
 ## Notes
 

--- a/skills/gemini/email-reply/SKILL.md
+++ b/skills/gemini/email-reply/SKILL.md
@@ -57,7 +57,7 @@ Help the user reply to an email with full thread context.
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--body-file "<path>"` — read the plain-text reply body from a file
    - `--html-body-file "<path>"` — read the HTML reply body from a file
-   - `--from-name "Name"` — override sender display name
+   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
    - `--priority <high|normal|low>` — set email priority
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)

--- a/skills/gemini/email-reply/SKILL.md
+++ b/skills/gemini/email-reply/SKILL.md
@@ -57,7 +57,6 @@ Help the user reply to an email with full thread context.
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--body-file "<path>"` — read the plain-text reply body from a file
    - `--html-body-file "<path>"` — read the HTML reply body from a file
-   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
    - `--priority <high|normal|low>` — set email priority
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)

--- a/skills/opencode/email-forward.md
+++ b/skills/opencode/email-forward.md
@@ -46,7 +46,6 @@ Help the user forward an email to another recipient.
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
    - `--cc "addr1,addr2"` — CC recipients (comma-separated)
-   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
 
 ## Notes
 

--- a/skills/opencode/email-forward.md
+++ b/skills/opencode/email-forward.md
@@ -46,7 +46,7 @@ Help the user forward an email to another recipient.
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)
    - `--cc "addr1,addr2"` — CC recipients (comma-separated)
-   - `--from-name "Name"` — override sender display name
+   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
 
 ## Notes
 

--- a/skills/opencode/email-reply.md
+++ b/skills/opencode/email-reply.md
@@ -56,7 +56,7 @@ Help the user reply to an email with full thread context.
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--body-file "<path>"` — read the plain-text reply body from a file
    - `--html-body-file "<path>"` — read the HTML reply body from a file
-   - `--from-name "Name"` — override sender display name
+   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
    - `--priority <high|normal|low>` — set email priority
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)

--- a/skills/opencode/email-reply.md
+++ b/skills/opencode/email-reply.md
@@ -56,7 +56,6 @@ Help the user reply to an email with full thread context.
    - `--html-body "<html>"` — send HTML-formatted reply
    - `--body-file "<path>"` — read the plain-text reply body from a file
    - `--html-body-file "<path>"` — read the HTML reply body from a file
-   - `--from-name "Name"` — deprecated and ignored; sender identity is enforced by InboxAPI
    - `--priority <high|normal|low>` — set email priority
    - `--attachment "<path>"` — attach a local file (repeatable for multiple files)
    - `--attachment-ref "<id>"` — attach by server-side attachment ID (repeatable)

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ enum Commands {
         #[arg(long = "html-body-file", conflicts_with = "html_body")]
         html_body_file: Option<PathBuf>,
         /// Deprecated and ignored by the server
-        #[arg(long)]
+        #[arg(long, hide = true)]
         from_name: Option<String>,
         /// Priority: low, normal, or high
         #[arg(long)]
@@ -208,7 +208,7 @@ enum Commands {
         #[arg(long = "html-body-file", conflicts_with = "html_body")]
         html_body_file: Option<PathBuf>,
         /// Deprecated and ignored by the server
-        #[arg(long)]
+        #[arg(long, hide = true)]
         from_name: Option<String>,
         /// Reply to all recipients in the thread
         #[arg(long)]
@@ -238,7 +238,7 @@ enum Commands {
         #[arg(long)]
         cc: Option<String>,
         /// Deprecated and ignored by the server
-        #[arg(long)]
+        #[arg(long, hide = true)]
         from_name: Option<String>,
         /// Attach a local file (can be repeated)
         #[arg(long = "attachment")]
@@ -1848,7 +1848,7 @@ fn build_send_email_args(
     cc: Option<&str>,
     bcc: Option<&str>,
     html_body: Option<&str>,
-    from_name: Option<&str>,
+    _from_name: Option<&str>,
     priority: Option<&str>,
     attachments_json: Vec<Value>,
 ) -> Value {
@@ -1865,9 +1865,6 @@ fn build_send_email_args(
     }
     if let Some(html_body) = html_body {
         args["html_body"] = json!(html_body);
-    }
-    if let Some(from_name) = from_name {
-        args["from_name"] = json!(from_name);
     }
     if let Some(priority) = priority {
         args["priority"] = json!(priority);
@@ -2342,7 +2339,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             ref bcc,
             ref html_body,
             ref html_body_file,
-            ref from_name,
+            from_name: _,
             ref priority,
             ref attachments,
             ref attachment_refs,
@@ -2376,7 +2373,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
                 cc.as_deref(),
                 bcc.as_deref(),
                 html_body.as_deref(),
-                from_name.as_deref(),
+                None,
                 priority.as_deref(),
                 attachment_entries,
             );
@@ -2479,7 +2476,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             ref bcc,
             ref html_body,
             ref html_body_file,
-            ref from_name,
+            from_name: _,
             reply_all,
             ref priority,
             ref attachments,
@@ -2523,9 +2520,6 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             if let Some(html_body) = html_body {
                 args["html_body"] = json!(html_body);
             }
-            if let Some(from_name) = from_name {
-                args["from_name"] = json!(from_name);
-            }
             if let Some(priority) = priority {
                 args["priority"] = json!(priority);
             }
@@ -2542,7 +2536,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             ref to,
             ref note,
             ref cc,
-            ref from_name,
+            from_name: _,
             ref attachments,
             ref attachment_refs,
         }) => {
@@ -2564,9 +2558,6 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             }
             if let Some(cc) = cc {
                 args["cc"] = json!(split_csv(cc));
-            }
-            if let Some(from_name) = from_name {
-                args["from_name"] = json!(from_name);
             }
             if !attachment_entries.is_empty() {
                 args["attachments"] = json!(attachment_entries);
@@ -4576,6 +4567,10 @@ fn inject_token(msg: &mut Value, credentials: &Credentials) {
                     if let Some(arguments) =
                         params.get_mut("arguments").and_then(|a| a.as_object_mut())
                     {
+                        if IDENTITY_TOOLS.contains(&name.as_str()) {
+                            arguments.remove("from_name");
+                        }
+
                         // Only inject if token is not already present
                         if !arguments.contains_key("token") {
                             arguments.insert("token".to_string(), json!(credentials.access_token));
@@ -4607,10 +4602,17 @@ fn sanitize_arguments(msg: &mut Value) {
     if let Some(method) = msg.get("method").and_then(|m| m.as_str()) {
         if method == "tools/call" {
             if let Some(params) = msg.get_mut("params").and_then(|p| p.as_object_mut()) {
+                let is_identity_tool = params
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .is_some_and(|name| IDENTITY_TOOLS.contains(&name));
                 if let Some(arguments) = params.get_mut("arguments").and_then(|a| a.as_object_mut())
                 {
                     arguments.remove("domain");
                     arguments.remove("access_token");
+                    if is_identity_tool {
+                        arguments.remove("from_name");
+                    }
                     let dunder_keys: Vec<String> = arguments
                         .keys()
                         .filter(|k| k.starts_with("__"))
@@ -5833,7 +5835,7 @@ mod tests {
             "[Bug Report] Login fails"
         );
         assert_eq!(msg["params"]["arguments"]["body"], "Steps to reproduce...");
-        assert!(msg["params"]["arguments"]["from_name"].is_null());
+        assert!(msg["params"]["arguments"].get("from_name").is_none());
     }
 
     #[test]
@@ -5889,7 +5891,7 @@ mod tests {
         let mut msg = make_tools_call("report_bug", json!({"subject": "Bug", "body": "Details"}));
         assert!(mutate_feedback_tool(&mut msg, None));
         assert_eq!(msg["params"]["name"], "send_email");
-        assert!(msg["params"]["arguments"]["from_name"].is_null());
+        assert!(msg["params"]["arguments"].get("from_name").is_none());
     }
 
     #[test]
@@ -6791,7 +6793,7 @@ mod tests {
         assert_eq!(args["reply_all"], true);
         assert_eq!(args["cc"], json!(["cc@test.com"]));
         assert_eq!(args["bcc"], json!(["bcc@test.com"]));
-        assert_eq!(args["from_name"], "agent");
+        assert!(args.get("from_name").is_none());
         assert_eq!(args["html_body"], "<p>Thanks</p>");
         assert_eq!(args["priority"], "high");
         assert_eq!(args["token"], "tok");
@@ -6819,7 +6821,7 @@ mod tests {
         assert_eq!(args["body"], "Hello");
         assert_eq!(args["cc"], json!(["cc@b.com"]));
         assert_eq!(args["bcc"], json!(["bcc@b.com"]));
-        assert_eq!(args["from_name"], "sender");
+        assert!(args.get("from_name").is_none());
         assert_eq!(args["html_body"], "<p>Hello</p>");
         assert_eq!(args["priority"], "low");
         assert_eq!(args["token"], "tok");
@@ -6842,7 +6844,7 @@ mod tests {
         assert_eq!(args["message_id"], "<fwd@test>");
         assert_eq!(args["to"], json!(["x@y.com"]));
         assert_eq!(args["cc"], json!(["cc@y.com"]));
-        assert_eq!(args["from_name"], "fwder");
+        assert!(args.get("from_name").is_none());
         assert_eq!(args["note"], "FYI");
         assert_eq!(args["token"], "tok");
     }
@@ -6955,7 +6957,8 @@ mod tests {
         );
         inject_token(&mut msg, &make_creds("tok"));
         let args = msg["params"]["arguments"].as_object().unwrap();
-        assert_eq!(args.len(), 9); // 8 fields + token
+        assert_eq!(args.len(), 8); // 7 fields + token; from_name is ignored
+        assert!(args.get("from_name").is_none());
         assert_eq!(args["token"], "tok");
     }
 
@@ -7051,7 +7054,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sanitize_preserves_normal_params() {
+    fn test_sanitize_strips_from_name_on_identity_tools() {
         let mut msg = make_tools_call(
             "send_email",
             json!({"to": "a@b.com", "subject": "Hi", "body": "Hello", "from_name": "Test"}),
@@ -7061,7 +7064,7 @@ mod tests {
         assert_eq!(args["to"], "a@b.com");
         assert_eq!(args["subject"], "Hi");
         assert_eq!(args["body"], "Hello");
-        assert_eq!(args["from_name"], "Test");
+        assert!(args.get("from_name").is_none());
     }
 
     // --- maxLength injection tests ---
@@ -7672,7 +7675,7 @@ mod tests {
             vec![],
         );
         assert_eq!(args["html_body"], "<p>Hello</p>");
-        assert_eq!(args["from_name"], "sender-name");
+        assert!(args.get("from_name").is_none());
         assert_eq!(args["priority"], "high");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,7 @@ enum Commands {
         /// Read the HTML body from a local file
         #[arg(long = "html-body-file", conflicts_with = "html_body")]
         html_body_file: Option<PathBuf>,
-        /// Sender display name
+        /// Deprecated and ignored by the server
         #[arg(long)]
         from_name: Option<String>,
         /// Priority: low, normal, or high
@@ -207,7 +207,7 @@ enum Commands {
         /// Read the HTML body from a local file
         #[arg(long = "html-body-file", conflicts_with = "html_body")]
         html_body_file: Option<PathBuf>,
-        /// Sender display name
+        /// Deprecated and ignored by the server
         #[arg(long)]
         from_name: Option<String>,
         /// Reply to all recipients in the thread
@@ -237,7 +237,7 @@ enum Commands {
         /// CC recipients, comma-separated
         #[arg(long)]
         cc: Option<String>,
-        /// Sender display name
+        /// Deprecated and ignored by the server
         #[arg(long)]
         from_name: Option<String>,
         /// Attach a local file (can be repeated)
@@ -3743,7 +3743,7 @@ fn is_whoami_call(msg: &Value) -> bool {
             .is_some_and(|n| n == "whoami")
 }
 
-fn mutate_feedback_tool(msg: &mut Value, creds: Option<&Credentials>) -> bool {
+fn mutate_feedback_tool(msg: &mut Value, _creds: Option<&Credentials>) -> bool {
     let is_tools_call = msg
         .get("method")
         .and_then(|m| m.as_str())
@@ -3779,16 +3779,12 @@ fn mutate_feedback_tool(msg: &mut Value, creds: Option<&Credentials>) -> bool {
         .and_then(|b| b.as_str())
         .unwrap_or("(no body)");
 
-    let mut new_args = json!({
+    let new_args = json!({
         "to": [to_addr],
         "subject": format!("{}{}", prefix, subject),
         "body": body,
         "allow_new_recipients": true,
     });
-
-    if let Some(c) = creds {
-        new_args["from_name"] = json!(c.account_name);
-    }
 
     if let Some(params) = msg.get_mut("params").and_then(|p| p.as_object_mut()) {
         params.insert("name".to_string(), json!("send_email"));
@@ -4024,12 +4020,10 @@ fn inject_initialize_instructions(
                 let name = sanitize_for_description(&c.account_name);
                 if let Some(ref email) = c.email {
                     let email = sanitize_for_description(email);
-                    let display = display_name_from_account(&c.account_name);
                     instructions.push_str(&format!(
                         " Your account name is '{}' and your InboxAPI email address is '{}'.\
-                         Use '{}' as your from_name when sending emails.\
-                         If you include a sign-off, you can use '{}' as your name.",
-                        name, email, name, display
+                         Outbound sender identity is enforced by InboxAPI; do not set from_name.",
+                        name, email
                     ));
                 }
             }
@@ -4297,8 +4291,8 @@ fn rewrite_tools_list(body: &str, creds: Option<&Credentials>) -> String {
                                     .and_then(|d| d.as_str())
                                     .unwrap_or("");
                                 let new_desc = format!(
-                                    "{}. Your account name is '{}' and your InboxAPI email is '{}'. Use '{}' as from_name. If you include a sign-off, you can use '{}' as your name. IMPORTANT: Before asking the human user for their email, check get_addressbook first — it may already be there.",
-                                    existing, san_name, san_email, san_name, display
+                                    "{}. Your account name is '{}' and your InboxAPI email is '{}'. Sender identity is enforced by InboxAPI; do not set from_name. If you include a sign-off, you can use '{}' as your name. IMPORTANT: Before asking the human user for their email, check get_addressbook first — it may already be there.",
+                                    existing, san_name, san_email, display
                                 );
                                 obj.insert("description".to_string(), json!(new_desc));
                             }
@@ -5377,7 +5371,8 @@ mod tests {
         let instructions = parsed["result"]["instructions"].as_str().unwrap();
         assert!(instructions.contains("test-agent"));
         assert!(instructions.contains("test-agent@inboxapi.io"));
-        assert!(instructions.contains("from_name"));
+        assert!(instructions.contains("Outbound sender identity is enforced"));
+        assert!(instructions.contains("do not set from_name"));
     }
 
     // --- rewrite_tools_list tests ---
@@ -5838,7 +5833,7 @@ mod tests {
             "[Bug Report] Login fails"
         );
         assert_eq!(msg["params"]["arguments"]["body"], "Steps to reproduce...");
-        assert_eq!(msg["params"]["arguments"]["from_name"], "cool-agent");
+        assert!(msg["params"]["arguments"]["from_name"].is_null());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- stop telling CLI proxy users and bundled skills to set from_name
- mark --from-name as deprecated/ignored in CLI help/docs
- stop injecting from_name in feedback-tool rewrites

## Root cause
The MCP server now enforces immutable sender identity, so CLI and agent guidance must not advertise mutable sender names.

## Validation
- cargo test
- cargo clippy --all-targets -- -D warnings