### PR TITLE
Fix verify-owner owner email argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1875,6 +1875,14 @@ fn build_send_email_args(
     args
 }
 
+fn build_verify_owner_args(email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({"owner_email": email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
+}
+
 fn resolve_body_input(
     inline: Option<&str>,
     file: Option<&Path>,
@@ -2702,10 +2710,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7716,6 +7721,29 @@ mod tests {
             vec![],
         );
         assert_eq!(args["to"], json!(["a@b.com", "c@d.com"]));
+    }
+
+    #[test]
+    fn test_verify_owner_args_uses_owner_email() {
+        let args = build_verify_owner_args("owner@example.com", None);
+
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert!(
+            args.get("email").is_none(),
+            "verify_owner must use owner_email, not email"
+        );
+        assert!(
+            args.get("code").is_none(),
+            "code should be omitted when no code is provided"
+        );
+    }
+
+    #[test]
+    fn test_verify_owner_args_includes_code() {
+        let args = build_verify_owner_args("owner@example.com", Some("123456"));
+
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "123456");
     }
 
     // --- build_attachment_from_file tests ---


### PR DESCRIPTION
## Summary
- send `owner_email` to the MCP `verify_owner` tool from the CLI `verify-owner` command
- factor verify-owner argument construction into a small helper
- add unit tests covering request and code submission payloads

## Verification
- `cargo fmt -- --check`
- `cargo test test_verify_owner_args -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test`
- `npm test`

## Risks / rollback
- Low-risk CLI payload fix for a single command path.
- Rollback by reverting commit `91e2a7f`.