### PR TITLE
Fail loudly when send-reply produces an empty sent body

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1675,8 +1675,16 @@ fn message_has_visible_body(message: &Value) -> bool {
     !body.is_empty() || !html_body.is_empty()
 }
 
+fn sent_email_items(sent_items: &Value) -> Option<&Vec<Value>> {
+    sent_items
+        .as_array()
+        .or_else(|| sent_items["sent_emails"].as_array())
+        .or_else(|| sent_items["emails"].as_array())
+        .or_else(|| sent_items["results"].as_array())
+}
+
 fn find_recent_sent_message<'a>(sent_items: &'a Value, message_id: &str) -> Option<&'a Value> {
-    sent_items.as_array()?.iter().find(|item| {
+    sent_email_items(sent_items)?.iter().find(|item| {
         item["message_id"]
             .as_str()
             .or_else(|| item["messageId"].as_str())
@@ -1694,7 +1702,9 @@ async fn verify_send_reply_delivery(
         return Ok(());
     };
 
-    for attempt in 0..3 {
+    const SEND_REPLY_VERIFY_ATTEMPTS: usize = 6;
+
+    for attempt in 0..SEND_REPLY_VERIFY_ATTEMPTS {
         let response = call_mcp_tool(
             endpoint,
             creds,
@@ -1706,18 +1716,37 @@ async fn verify_send_reply_delivery(
         let sent_text = extract_tool_result_text(&response)?;
         if let Ok(sent_items) = serde_json::from_str::<Value>(&sent_text) {
             if let Some(message) = find_recent_sent_message(&sent_items, &message_id) {
-                if !message_has_visible_body(message) {
+                if message_has_visible_body(message) {
+                    return Ok(());
+                }
+                if let Ok(email_response) = call_mcp_tool(
+                    endpoint,
+                    creds,
+                    http_client,
+                    "get_email",
+                    json!({"message_id": message_id, "content_format": "all"}),
+                )
+                .await
+                {
+                    if let Ok(email_text) = extract_tool_result_text(&email_response) {
+                        if let Ok(email) = serde_json::from_str::<Value>(&email_text) {
+                            if message_has_visible_body(&email) {
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+                if attempt + 1 == SEND_REPLY_VERIFY_ATTEMPTS {
                     return Err(anyhow!(
                         "send-reply reported success, but sent message {} has an empty body",
                         message_id
                     ));
                 }
-                return Ok(());
             }
         }
 
-        if attempt < 2 {
-            tokio::time::sleep(Duration::from_millis(750)).await;
+        if attempt + 1 < SEND_REPLY_VERIFY_ATTEMPTS {
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
     }
 
@@ -7055,6 +7084,20 @@ mod tests {
             {"message_id": "<one@test>", "body": "first"},
             {"message_id": "<two@test>", "body": "second"}
         ]);
+        let message = find_recent_sent_message(&sent_items, "<two@test>").unwrap();
+        assert_eq!(message["body"], "second");
+    }
+
+    #[test]
+    fn test_find_recent_sent_message_matches_wrapped_sent_emails() {
+        let sent_items = json!({
+            "total": 2,
+            "sent_emails": [
+                {"message_id": "<one@test>", "body": "first"},
+                {"message_id": "<two@test>", "body": "second"}
+            ],
+            "returned": 2
+        });
         let message = find_recent_sent_message(&sent_items, "<two@test>").unwrap();
         assert_eq!(message["body"], "second");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1658,6 +1658,72 @@ fn extract_tool_result_text(response: &Value) -> Result<String> {
         .ok_or_else(|| anyhow!("No text content in response"))
 }
 
+fn extract_message_id(text: &str) -> Option<String> {
+    let data: Value = serde_json::from_str(text).ok()?;
+    data["message_id"]
+        .as_str()
+        .or_else(|| data["messageId"].as_str())
+        .map(ToOwned::to_owned)
+}
+
+fn message_has_visible_body(message: &Value) -> bool {
+    let body = message["body"].as_str().unwrap_or_default();
+    let html_body = message["html_body"]
+        .as_str()
+        .or_else(|| message["htmlBody"].as_str())
+        .unwrap_or_default();
+    !body.is_empty() || !html_body.is_empty()
+}
+
+fn find_recent_sent_message<'a>(sent_items: &'a Value, message_id: &str) -> Option<&'a Value> {
+    sent_items.as_array()?.iter().find(|item| {
+        item["message_id"]
+            .as_str()
+            .or_else(|| item["messageId"].as_str())
+            .is_some_and(|id| id == message_id)
+    })
+}
+
+async fn verify_send_reply_delivery(
+    endpoint: &str,
+    creds: &mut Option<Credentials>,
+    http_client: &HttpClient,
+    response_text: &str,
+) -> Result<()> {
+    let Some(message_id) = extract_message_id(response_text) else {
+        return Ok(());
+    };
+
+    for attempt in 0..3 {
+        let response = call_mcp_tool(
+            endpoint,
+            creds,
+            http_client,
+            "get_sent_emails",
+            json!({"limit": 10}),
+        )
+        .await?;
+        let sent_text = extract_tool_result_text(&response)?;
+        if let Ok(sent_items) = serde_json::from_str::<Value>(&sent_text) {
+            if let Some(message) = find_recent_sent_message(&sent_items, &message_id) {
+                if !message_has_visible_body(message) {
+                    return Err(anyhow!(
+                        "send-reply reported success, but sent message {} has an empty body",
+                        message_id
+                    ));
+                }
+                return Ok(());
+            }
+        }
+
+        if attempt < 2 {
+            tokio::time::sleep(Duration::from_millis(750)).await;
+        }
+    }
+
+    Ok(())
+}
+
 /// Split a comma-separated string into a Vec of trimmed strings.
 fn split_csv(s: &str) -> Vec<String> {
     s.split(',')
@@ -2529,6 +2595,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "send_reply", args).await?;
             let text = extract_tool_result_text(&response)?;
+            verify_send_reply_delivery(&endpoint, &mut creds, &http_client, &text).await?;
             print_result("send_reply", &text, cli.human);
         }
         Some(Commands::ForwardEmail {
@@ -6974,6 +7041,34 @@ mod tests {
         assert_eq!(args["in_reply_to"], "<msg@test>");
         assert_eq!(args["body"], "reply");
         assert_eq!(args["token"], "tok");
+    }
+
+    #[test]
+    fn test_extract_message_id_from_send_reply_result() {
+        let text = r#"{"message_id":"<reply@test>","status":"queued"}"#;
+        assert_eq!(extract_message_id(text).as_deref(), Some("<reply@test>"));
+    }
+
+    #[test]
+    fn test_find_recent_sent_message_matches_message_id() {
+        let sent_items = json!([
+            {"message_id": "<one@test>", "body": "first"},
+            {"message_id": "<two@test>", "body": "second"}
+        ]);
+        let message = find_recent_sent_message(&sent_items, "<two@test>").unwrap();
+        assert_eq!(message["body"], "second");
+    }
+
+    #[test]
+    fn test_message_has_visible_body_accepts_plain_or_html() {
+        assert!(message_has_visible_body(&json!({"body": "reply"})));
+        assert!(message_has_visible_body(
+            &json!({"html_body": "<p>reply</p>"})
+        ));
+        assert!(!message_has_visible_body(
+            &json!({"body": "", "html_body": ""})
+        ));
+        assert!(!message_has_visible_body(&json!({})));
     }
 
     // --- sanitize_arguments tests ---


### PR DESCRIPTION
## Summary
- verify newly queued `send-reply` deliveries against recent sent mail entries
- handle current `get-sent-emails` wrapped response shape (`sent_emails`) as well as array-style responses
- retry transient empty sent rows and cross-check `get_email` before failing loudly
- add focused unit coverage for reply result parsing and empty-body detection helpers

Fixes #51.

## Validation
- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build --release`
- Live smoke with release binary as `vish@inboxapi.ai`: `send-email` to self, then `send-reply --reply-all --body-file --html-body-file`; verified sent ledger had a non-empty reply body and recipient `vish@inboxapi.ai`.

## Rollback
- Revert this PR to restore the previous CLI behaviour. No production deploy or installed stable CLI replacement was performed during validation.