### PR TITLE
Fix verify-owner owner_email payload

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -302,8 +302,8 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", visible_alias = "email", alias = "owner_email")]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -1875,6 +1875,15 @@ fn build_send_email_args(
     args
 }
 
+/// Build the arguments JSON for verify_owner from CLI args.
+fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({"owner_email": owner_email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
+}
+
 fn resolve_body_input(
     inline: Option<&str>,
     file: Option<&Path>,
@@ -2281,6 +2290,7 @@ Examples:
   inboxapi send-reply --message-id \"<msg-id>\" --body \"Thanks!\"
   inboxapi send-reply --message-id \"<msg-id>\" --body-file ./reply.txt --html-body-file ./reply.html
   inboxapi forward-email --message-id \"<msg-id>\" --to recipient@example.com
+  inboxapi verify-owner --owner-email user@example.com
 ";
 
 /// Run a simple MCP tool call with no arguments, print the result.
@@ -2692,20 +2702,17 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(owner_email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7574,6 +7581,56 @@ mod tests {
                 other.map(|_| "other")
             ),
         }
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_owner_email_flag() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--owner-email",
+            "user@example.com",
+            "--code",
+            "123456",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner { owner_email, code }) => {
+                assert_eq!(owner_email, "user@example.com");
+                assert_eq!(code.as_deref(), Some("123456"));
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_legacy_email_flag() {
+        let cli = Cli::try_parse_from(["inboxapi", "verify-owner", "--email", "user@example.com"])
+            .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner { owner_email, code }) => {
+                assert_eq!(owner_email, "user@example.com");
+                assert!(code.is_none());
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_build_verify_owner_args_uses_owner_email_key() {
+        let args = build_verify_owner_args("user@example.com", Some("123456"));
+
+        assert_eq!(args["owner_email"], "user@example.com");
+        assert_eq!(args["code"], "123456");
+        assert!(args.get("email").is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7597,8 +7597,15 @@ mod tests {
 
         match cli.command {
             Some(Commands::VerifyOwner { owner_email, code }) => {
-                assert_eq!(owner_email, "user@example.com");
-                assert_eq!(code.as_deref(), Some("123456"));
+                assert_eq!(
+                    owner_email, "user@example.com",
+                    "expected --owner-email to populate owner_email"
+                );
+                assert_eq!(
+                    code.as_deref(),
+                    Some("123456"),
+                    "expected --code to populate verify-owner code"
+                );
             }
             other => panic!(
                 "expected VerifyOwner command, got {:?}",
@@ -7614,8 +7621,14 @@ mod tests {
 
         match cli.command {
             Some(Commands::VerifyOwner { owner_email, code }) => {
-                assert_eq!(owner_email, "user@example.com");
-                assert!(code.is_none());
+                assert_eq!(
+                    owner_email, "user@example.com",
+                    "expected legacy --email alias to populate owner_email"
+                );
+                assert!(
+                    code.is_none(),
+                    "expected code to be absent when --code is not provided"
+                );
             }
             other => panic!(
                 "expected VerifyOwner command, got {:?}",
@@ -7628,9 +7641,18 @@ mod tests {
     fn test_build_verify_owner_args_uses_owner_email_key() {
         let args = build_verify_owner_args("user@example.com", Some("123456"));
 
-        assert_eq!(args["owner_email"], "user@example.com");
-        assert_eq!(args["code"], "123456");
-        assert!(args.get("email").is_none());
+        assert_eq!(
+            args["owner_email"], "user@example.com",
+            "expected verify_owner payload to use owner_email key"
+        );
+        assert_eq!(
+            args["code"], "123456",
+            "expected verify_owner payload to include provided code"
+        );
+        assert!(
+            args.get("email").is_none(),
+            "expected legacy email key to be omitted from verify_owner payload"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Change verify-owner to send `owner_email` to the MCP API instead of `email`.
- Add `--owner-email` as the primary CLI flag while keeping legacy `--email` and `--owner_email` aliases.
- Add parser and payload regression tests.

Closes #52.

## Tests
- `cargo fmt -- --check`
- `cargo test`
- `cargo clippy -- -D warnings`

Note: `make qa` is not available in this repo.

## Risks / trade-offs
- Low risk: preserves the existing `--email` flag as an alias for compatibility.
- Help now advertises `--owner-email`, which matches the API field more clearly.

## Rollback
- Revert commit `1389e5c` to restore prior CLI flag/payload behaviour.