### PR TITLE
[codex] Fix owner verification CLI schema

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -290,10 +290,10 @@ enum Commands {
     /// Recover a lost account
     AccountRecover {
         /// Account name
-        #[arg(long)]
+        #[arg(long, alias = "account-name")]
         name: String,
         /// Recovery email address
-        #[arg(long)]
+        #[arg(long, alias = "owner-email", alias = "owner_email")]
         email: String,
         /// Recovery code (if already received)
         #[arg(long)]
@@ -302,8 +302,8 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", alias = "email", alias = "owner_email")]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -1875,6 +1875,27 @@ fn build_send_email_args(
     args
 }
 
+fn build_account_recover_args(name: &str, email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({
+        "account_name": name,
+        "owner_email": email,
+    });
+    if let Some(code) = code {
+        args["code"] = json!(code.trim());
+    }
+    args
+}
+
+fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({
+        "owner_email": owner_email,
+    });
+    if let Some(code) = code {
+        args["code"] = json!(code.trim());
+    }
+    args
+}
+
 fn resolve_body_input(
     inline: Option<&str>,
     file: Option<&Path>,
@@ -2676,7 +2697,6 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             ref email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
             if let Some(code) = code {
                 let c = code.trim();
                 if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
@@ -2684,28 +2704,25 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
                         "Invalid recovery code format. Expected a 6-digit numeric code."
                     ));
                 }
-                args["code"] = json!(c);
             }
+            let args = build_account_recover_args(name, email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
             let text = extract_tool_result_text(&response)?;
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(owner_email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -5062,6 +5079,72 @@ mod tests {
         inject_token(&mut msg, &make_creds("test-token"));
 
         assert!(msg["params"]["arguments"]["token"].is_null());
+    }
+
+    #[test]
+    fn build_account_recover_args_uses_mcp_schema_names() {
+        let args = build_account_recover_args("agent-one", "owner@example.com", Some(" 123456 "));
+
+        assert_eq!(
+            args,
+            json!({
+                "account_name": "agent-one",
+                "owner_email": "owner@example.com",
+                "code": "123456",
+            })
+        );
+        assert!(args.get("name").is_none());
+        assert!(args.get("email").is_none());
+    }
+
+    #[test]
+    fn build_verify_owner_args_uses_owner_email() {
+        let args = build_verify_owner_args("owner@example.com", Some(" 654321 "));
+
+        assert_eq!(
+            args,
+            json!({
+                "owner_email": "owner@example.com",
+                "code": "654321",
+            })
+        );
+        assert!(args.get("email").is_none());
+    }
+
+    #[test]
+    fn verify_owner_accepts_legacy_email_flag() {
+        let cli = Cli::try_parse_from(["inboxapi", "verify-owner", "--email", "owner@example.com"])
+            .unwrap();
+
+        match cli.command.unwrap() {
+            Commands::VerifyOwner { owner_email, code } => {
+                assert_eq!(owner_email, "owner@example.com");
+                assert_eq!(code, None);
+            }
+            _ => panic!("expected verify-owner command"),
+        }
+    }
+
+    #[test]
+    fn account_recover_accepts_explicit_schema_flags() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "account-recover",
+            "--account-name",
+            "agent-one",
+            "--owner-email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command.unwrap() {
+            Commands::AccountRecover { name, email, code } => {
+                assert_eq!(name, "agent-one");
+                assert_eq!(email, "owner@example.com");
+                assert_eq!(code, None);
+            }
+            _ => panic!("expected account-recover command"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Updated `verify-owner` to send `owner_email` to the MCP `verify_owner` tool while keeping `--email` as a backwards-compatible alias.
- Updated `account-recover` to send `account_name` / `owner_email` to match the MCP schema, with `--account-name` and `--owner-email` aliases.
- Added unit coverage for argument builders and CLI alias parsing.

## Root cause

The CLI command was building payloads with CLI-facing names (`email`, `name`) instead of the MCP tool schema names expected by the backend.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`

## Rollback

Revert this PR; the change is isolated to CLI argument parsing/payload construction and tests.
