### PR TITLE
Fix owner verification CLI payloads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2299,17 +2299,43 @@ async fn run_simple_command(
     Ok(())
 }
 
-fn account_recover_args(account_name: &str, owner_email: &str) -> Value {
-    json!({
-        "account_name": account_name,
-        "owner_email": owner_email,
+fn six_digit_code(code: Option<&str>, kind: &str) -> Result<Option<String>> {
+    code.map(|code| {
+        let c = code.trim();
+        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
+            return Err(anyhow!(
+                "Invalid {} code format. Expected a 6-digit numeric code.",
+                kind
+            ));
+        }
+        Ok(c.to_string())
     })
+    .transpose()
 }
 
-fn verify_owner_args(owner_email: &str) -> Value {
-    json!({
+fn account_recover_args(
+    account_name: &str,
+    owner_email: &str,
+    code: Option<&str>,
+) -> Result<Value> {
+    let mut args = json!({
+        "account_name": account_name,
         "owner_email": owner_email,
-    })
+    });
+    if let Some(code) = six_digit_code(code, "recovery")? {
+        args["code"] = json!(code);
+    }
+    Ok(args)
+}
+
+fn verify_owner_args(owner_email: &str, code: Option<&str>) -> Result<Value> {
+    let mut args = json!({
+        "owner_email": owner_email,
+    });
+    if let Some(code) = six_digit_code(code, "verification")? {
+        args["code"] = json!(code);
+    }
+    Ok(args)
 }
 
 /// Run a CLI subcommand that calls an MCP tool.
@@ -2691,16 +2717,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             ref owner_email,
             ref code,
         }) => {
-            let mut args = account_recover_args(account_name, owner_email);
-            if let Some(code) = code {
-                let c = code.trim();
-                if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-                    return Err(anyhow!(
-                        "Invalid recovery code format. Expected a 6-digit numeric code."
-                    ));
-                }
-                args["code"] = json!(c);
-            }
+            let args = account_recover_args(account_name, owner_email, code.as_deref())?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -2717,10 +2734,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = verify_owner_args(owner_email);
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = verify_owner_args(owner_email, code.as_deref())?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7633,10 +7647,23 @@ mod tests {
 
     #[test]
     fn test_verify_owner_args_use_api_field_names() {
-        let args = verify_owner_args("owner@example.com");
+        let args = verify_owner_args("owner@example.com", None).expect("missing code is valid");
 
         assert_eq!(args["owner_email"], "owner@example.com");
         assert!(args["email"].is_null());
+    }
+
+    #[test]
+    fn test_verify_owner_args_trim_and_validate_code() {
+        let args = verify_owner_args("owner@example.com", Some(" 654321 "))
+            .expect("valid verification code should not fail");
+
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "654321");
+
+        let err = verify_owner_args("owner@example.com", Some("65432a"))
+            .expect_err("non-numeric verification code should fail");
+        assert!(err.to_string().contains("Invalid verification code format"));
     }
 
     #[test]
@@ -7678,12 +7705,22 @@ mod tests {
 
     #[test]
     fn test_account_recover_args_use_api_field_names() {
-        let args = account_recover_args("test-agent", "owner@example.com");
+        let args = account_recover_args("test-agent", "owner@example.com", Some(" 123456 "))
+            .expect("valid recovery code should not fail");
 
         assert_eq!(args["account_name"], "test-agent");
         assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "123456");
         assert!(args["name"].is_null());
         assert!(args["email"].is_null());
+    }
+
+    #[test]
+    fn test_account_recover_args_reject_invalid_code() {
+        let err = account_recover_args("test-agent", "owner@example.com", Some("12345"))
+            .expect_err("short recovery code should fail");
+
+        assert!(err.to_string().contains("Invalid recovery code format"));
     }
 
     // --- guess_content_type tests ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -2230,19 +2230,6 @@ fn print_result(tool_name: &str, text: &str, human: bool) {
     }
 }
 
-fn account_recover_args(account_name: &str, owner_email: &str) -> Value {
-    json!({
-        "account_name": account_name,
-        "owner_email": owner_email,
-    })
-}
-
-fn verify_owner_args(owner_email: &str) -> Value {
-    json!({
-        "owner_email": owner_email,
-    })
-}
-
 const CLI_HELP_TEXT: &str = "\
 inboxapi — Email for your AI
 
@@ -2310,6 +2297,19 @@ async fn run_simple_command(
     let text = extract_tool_result_text(&response)?;
     print_result(tool_name, &text, human);
     Ok(())
+}
+
+fn account_recover_args(account_name: &str, owner_email: &str) -> Value {
+    json!({
+        "account_name": account_name,
+        "owner_email": owner_email,
+    })
+}
+
+fn verify_owner_args(owner_email: &str) -> Value {
+    json!({
+        "owner_email": owner_email,
+    })
 }
 
 /// Run a CLI subcommand that calls an MCP tool.

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,11 +290,11 @@ enum Commands {
     /// Recover a lost account
     AccountRecover {
         /// Account name
-        #[arg(long)]
-        name: String,
+        #[arg(long = "account-name", alias = "account_name", visible_alias = "name")]
+        account_name: String,
         /// Recovery email address
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", alias = "owner_email", visible_alias = "email")]
+        owner_email: String,
         /// Recovery code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -302,8 +302,8 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", alias = "owner_email", visible_alias = "email")]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -2230,6 +2230,19 @@ fn print_result(tool_name: &str, text: &str, human: bool) {
     }
 }
 
+fn account_recover_args(account_name: &str, owner_email: &str) -> Value {
+    json!({
+        "account_name": account_name,
+        "owner_email": owner_email,
+    })
+}
+
+fn verify_owner_args(owner_email: &str) -> Value {
+    json!({
+        "owner_email": owner_email,
+    })
+}
+
 const CLI_HELP_TEXT: &str = "\
 inboxapi — Email for your AI
 
@@ -2281,6 +2294,8 @@ Examples:
   inboxapi send-reply --message-id \"<msg-id>\" --body \"Thanks!\"
   inboxapi send-reply --message-id \"<msg-id>\" --body-file ./reply.txt --html-body-file ./reply.html
   inboxapi forward-email --message-id \"<msg-id>\" --to recipient@example.com
+  inboxapi verify-owner --owner-email owner@example.com
+  inboxapi account-recover --account-name agent-name --owner-email owner@example.com
 ";
 
 /// Run a simple MCP tool call with no arguments, print the result.
@@ -2672,11 +2687,11 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             .await?;
         }
         Some(Commands::AccountRecover {
-            ref name,
-            ref email,
+            ref account_name,
+            ref owner_email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
+            let mut args = account_recover_args(account_name, owner_email);
             if let Some(code) = code {
                 let c = code.trim();
                 if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
@@ -2692,17 +2707,17 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
+            let mut args = verify_owner_args(owner_email);
             if let Some(code) = code {
                 args["code"] = json!(code);
             }
@@ -7595,6 +7610,80 @@ mod tests {
         );
         let err = result.err().unwrap();
         assert!(err.to_string().contains("--body-file"));
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_owner_email_flags() {
+        for flag in ["--owner-email", "--owner_email", "--email"] {
+            let cli = Cli::try_parse_from(["inboxapi", "verify-owner", flag, "owner@example.com"])
+                .unwrap();
+
+            match cli.command {
+                Some(Commands::VerifyOwner { owner_email, code }) => {
+                    assert_eq!(owner_email, "owner@example.com");
+                    assert!(code.is_none());
+                }
+                other => panic!(
+                    "expected VerifyOwner command, got {:?}",
+                    other.map(|_| "other")
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_verify_owner_args_use_api_field_names() {
+        let args = verify_owner_args("owner@example.com");
+
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert!(args["email"].is_null());
+    }
+
+    #[test]
+    fn test_account_recover_accepts_new_and_legacy_flags() {
+        let cases = [
+            ("--account-name", "--owner-email"),
+            ("--account_name", "--owner_email"),
+            ("--name", "--email"),
+        ];
+
+        for (name_flag, email_flag) in cases {
+            let cli = Cli::try_parse_from([
+                "inboxapi",
+                "account-recover",
+                name_flag,
+                "test-agent",
+                email_flag,
+                "owner@example.com",
+            ])
+            .unwrap();
+
+            match cli.command {
+                Some(Commands::AccountRecover {
+                    account_name,
+                    owner_email,
+                    code,
+                }) => {
+                    assert_eq!(account_name, "test-agent");
+                    assert_eq!(owner_email, "owner@example.com");
+                    assert!(code.is_none());
+                }
+                other => panic!(
+                    "expected AccountRecover command, got {:?}",
+                    other.map(|_| "other")
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_account_recover_args_use_api_field_names() {
+        let args = account_recover_args("test-agent", "owner@example.com");
+
+        assert_eq!(args["account_name"], "test-agent");
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert!(args["name"].is_null());
+        assert!(args["email"].is_null());
     }
 
     // --- guess_content_type tests ---


### PR DESCRIPTION
## Summary
- send verify-owner payloads with owner_email instead of email
- send account-recover payloads with account_name/owner_email instead of name/email
- accept --owner-email/--owner_email and --account-name/--account_name while keeping --email/--name as visible legacy aliases
- add focused CLI parsing and payload regression tests

Fixes #52.

## Tests
- cargo fmt --check
- cargo test
- cargo clippy -- -D warnings

## Risks / rollback
- Low risk: scoped to owner verification/recovery command argument mapping.
- Rollback: revert commit 482d2bb if command compatibility or API field expectations differ.