### PR TITLE
Fail loudly when send-reply yields empty sent body

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1658,6 +1658,72 @@ fn extract_tool_result_text(response: &Value) -> Result<String> {
         .ok_or_else(|| anyhow!("No text content in response"))
 }
 
+fn extract_message_id(text: &str) -> Option<String> {
+    let data: Value = serde_json::from_str(text).ok()?;
+    data["message_id"]
+        .as_str()
+        .or_else(|| data["messageId"].as_str())
+        .map(ToOwned::to_owned)
+}
+
+fn message_has_visible_body(message: &Value) -> bool {
+    let body = message["body"].as_str().unwrap_or_default();
+    let html_body = message["html_body"]
+        .as_str()
+        .or_else(|| message["htmlBody"].as_str())
+        .unwrap_or_default();
+    !body.is_empty() || !html_body.is_empty()
+}
+
+fn find_recent_sent_message<'a>(sent_items: &'a Value, message_id: &str) -> Option<&'a Value> {
+    sent_items.as_array()?.iter().find(|item| {
+        item["message_id"]
+            .as_str()
+            .or_else(|| item["messageId"].as_str())
+            .is_some_and(|id| id == message_id)
+    })
+}
+
+async fn verify_send_reply_delivery(
+    endpoint: &str,
+    creds: &mut Option<Credentials>,
+    http_client: &HttpClient,
+    response_text: &str,
+) -> Result<()> {
+    let Some(message_id) = extract_message_id(response_text) else {
+        return Ok(());
+    };
+
+    for attempt in 0..3 {
+        let response = call_mcp_tool(
+            endpoint,
+            creds,
+            http_client,
+            "get_sent_emails",
+            json!({"limit": 10}),
+        )
+        .await?;
+        let sent_text = extract_tool_result_text(&response)?;
+        if let Ok(sent_items) = serde_json::from_str::<Value>(&sent_text) {
+            if let Some(message) = find_recent_sent_message(&sent_items, &message_id) {
+                if !message_has_visible_body(message) {
+                    return Err(anyhow!(
+                        "send-reply reported success, but sent message {} has an empty body",
+                        message_id
+                    ));
+                }
+                return Ok(());
+            }
+        }
+
+        if attempt < 2 {
+            tokio::time::sleep(Duration::from_millis(750)).await;
+        }
+    }
+
+    Ok(())
+}
+
 /// Split a comma-separated string into a Vec of trimmed strings.
 fn split_csv(s: &str) -> Vec<String> {
     s.split(',')
@@ -2529,6 +2595,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "send_reply", args).await?;
             let text = extract_tool_result_text(&response)?;
+            verify_send_reply_delivery(&endpoint, &mut creds, &http_client, &text).await?;
             print_result("send_reply", &text, cli.human);
         }
         Some(Commands::ForwardEmail {
@@ -6873,6 +6940,34 @@ mod tests {
         assert_eq!(attachments[1]["filename"], "photo.jpg");
         assert_eq!(attachments[1]["content_type"], "image/jpeg");
         assert_eq!(args["token"], "tok");
+    }
+
+    #[test]
+    fn test_extract_message_id_from_send_reply_result() {
+        let text = r#"{"message_id":"<reply@test>","status":"queued"}"#;
+        assert_eq!(extract_message_id(text).as_deref(), Some("<reply@test>"));
+    }
+
+    #[test]
+    fn test_find_recent_sent_message_matches_message_id() {
+        let sent_items = json!([
+            {"message_id": "<one@test>", "body": "first"},
+            {"message_id": "<two@test>", "body": "second"}
+        ]);
+        let message = find_recent_sent_message(&sent_items, "<two@test>").unwrap();
+        assert_eq!(message["body"], "second");
+    }
+
+    #[test]
+    fn test_message_has_visible_body_accepts_plain_or_html() {
+        assert!(message_has_visible_body(&json!({"body": "reply"})));
+        assert!(message_has_visible_body(
+            &json!({"html_body": "<p>reply</p>"})
+        ));
+        assert!(!message_has_visible_body(
+            &json!({"body": "", "html_body": ""})
+        ));
+        assert!(!message_has_visible_body(&json!({})));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- verify queued `send-reply` deliveries by checking recent sent mail entries
- fail the CLI when the matching sent record has neither plain-text nor HTML body
- add unit tests for message-id extraction, sent-message lookup, and empty-body detection

Fixes #51.

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test test_extract_message_id_from_send_reply_result -- --nocapture`
- `cargo test test_find_recent_sent_message_matches_message_id -- --nocapture`
- `cargo test test_message_has_visible_body_accepts_plain_or_html -- --nocapture`
- `cargo build --release`
- `./target/release/inboxapi-cli whoami`
- `./target/release/inboxapi-cli get-email-count`

## Rollback
- Backed up current stable binary to `repo/.backup/inboxapi.stable` before smoke testing the new release binary.
