### PR TITLE
Fix owner verification CLI payloads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -290,20 +290,20 @@ enum Commands {
     /// Recover a lost account
     AccountRecover {
         /// Account name
-        #[arg(long)]
-        name: String,
-        /// Recovery email address
-        #[arg(long)]
-        email: String,
+        #[arg(long = "account-name", alias = "account_name", visible_alias = "name")]
+        account_name: String,
+        /// Verified owner email address
+        #[arg(long = "owner-email", alias = "owner_email", visible_alias = "email")]
+        owner_email: String,
         /// Recovery code (if already received)
         #[arg(long)]
         code: Option<String>,
     },
     /// Verify email ownership
     VerifyOwner {
-        /// Email address to verify
-        #[arg(long)]
-        email: String,
+        /// Owner email address to verify
+        #[arg(long = "owner-email", alias = "owner_email", visible_alias = "email")]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -525,6 +525,32 @@ fn save_credentials(creds: &Credentials) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn build_account_recover_args(
+    account_name: &str,
+    owner_email: &str,
+    code: &Option<String>,
+) -> Result<Value> {
+    let mut args = json!({"account_name": account_name, "owner_email": owner_email});
+    if let Some(code) = code {
+        let c = code.trim();
+        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
+            return Err(anyhow!(
+                "Invalid recovery code format. Expected a 6-digit numeric code."
+            ));
+        }
+        args["code"] = json!(c);
+    }
+    Ok(args)
+}
+
+fn build_verify_owner_args(owner_email: &str, code: &Option<String>) -> Value {
+    let mut args = json!({"owner_email": owner_email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
 }
 
 fn prompt_yes_no(prompt: &str) -> bool {
@@ -2672,40 +2698,28 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             .await?;
         }
         Some(Commands::AccountRecover {
-            ref name,
-            ref email,
+            ref account_name,
+            ref owner_email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
-            if let Some(code) = code {
-                let c = code.trim();
-                if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-                    return Err(anyhow!(
-                        "Invalid recovery code format. Expected a 6-digit numeric code."
-                    ));
-                }
-                args["code"] = json!(c);
-            }
+            let args = build_account_recover_args(account_name, owner_email, code)?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
             let text = extract_tool_result_text(&response)?;
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(owner_email, code);
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7539,6 +7553,105 @@ mod tests {
     }
 
     // --- CLI parsing tests ---
+
+    #[test]
+    fn test_verify_owner_accepts_owner_email_and_email_alias() {
+        for flag in ["--owner-email", "--owner_email", "--email"] {
+            let cli = Cli::try_parse_from(["inboxapi", "verify-owner", flag, "owner@example.com"])
+                .unwrap();
+
+            match cli.command {
+                Some(Commands::VerifyOwner {
+                    owner_email, code, ..
+                }) => {
+                    assert_eq!(owner_email, "owner@example.com");
+                    assert!(code.is_none());
+                }
+                other => panic!(
+                    "expected VerifyOwner command, got {:?}",
+                    other.map(|_| "other")
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_account_recover_accepts_new_flags_and_legacy_aliases() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "account-recover",
+            "--account-name",
+            "agent",
+            "--owner-email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::AccountRecover {
+                account_name,
+                owner_email,
+                code,
+                ..
+            }) => {
+                assert_eq!(account_name, "agent");
+                assert_eq!(owner_email, "owner@example.com");
+                assert!(code.is_none());
+            }
+            other => panic!(
+                "expected AccountRecover command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "account-recover",
+            "--name",
+            "agent",
+            "--email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::AccountRecover {
+                account_name,
+                owner_email,
+                ..
+            }) => {
+                assert_eq!(account_name, "agent");
+                assert_eq!(owner_email, "owner@example.com");
+            }
+            other => panic!(
+                "expected AccountRecover command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_recovery_payloads_use_api_field_names() {
+        assert_eq!(
+            build_verify_owner_args("owner@example.com", &Some("123456".to_string())),
+            json!({"owner_email": "owner@example.com", "code": "123456"})
+        );
+
+        assert_eq!(
+            build_account_recover_args("agent", "owner@example.com", &Some(" 123456 ".to_string()))
+                .unwrap(),
+            json!({"account_name": "agent", "owner_email": "owner@example.com", "code": "123456"})
+        );
+    }
+
+    #[test]
+    fn test_account_recover_rejects_invalid_code() {
+        let err =
+            build_account_recover_args("agent", "owner@example.com", &Some("abc123".to_string()))
+                .unwrap_err();
+
+        assert!(err.to_string().contains("6-digit numeric code"));
+    }
 
     #[test]
     fn test_send_email_accepts_body_file_flags() {


### PR DESCRIPTION
## Summary
- Fix `verify-owner` to send `owner_email` to the MCP API instead of `email`.
- Fix `account-recover` to send `account_name` and `owner_email`, matching the API schema.
- Prefer `--owner-email` / `--account-name` in CLI parsing while keeping `--email` / `--name` as visible legacy aliases, plus hidden underscore aliases.

## Root Cause
The CLI argument names leaked directly into the JSON payload for recovery flows. The server schema expects API field names (`owner_email`, `account_name`), so `verify-owner --email ...` failed deserialization.

## Validation
- `cargo test recover -- --nocapture`
- `cargo test verify_owner -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test`

Closes #52
