### PR TITLE
[codex] Fix owner email CLI payloads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -290,11 +290,11 @@ enum Commands {
     /// Recover a lost account
     AccountRecover {
         /// Account name
-        #[arg(long)]
-        name: String,
+        #[arg(long = "account-name", visible_alias = "name")]
+        account_name: String,
         /// Recovery email address
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", visible_alias = "email", alias = "owner_email")]
+        owner_email: String,
         /// Recovery code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -302,8 +302,8 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", visible_alias = "email", alias = "owner_email")]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -2672,40 +2672,28 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             .await?;
         }
         Some(Commands::AccountRecover {
-            ref name,
-            ref email,
+            ref account_name,
+            ref owner_email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
-            if let Some(code) = code {
-                let c = code.trim();
-                if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-                    return Err(anyhow!(
-                        "Invalid recovery code format. Expected a 6-digit numeric code."
-                    ));
-                }
-                args["code"] = json!(c);
-            }
+            let args = build_account_recover_args(account_name, owner_email, code.as_deref())?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
             let text = extract_tool_result_text(&response)?;
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(owner_email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -2803,6 +2791,32 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
         _ => unreachable!("run_cli_command called with non-CLI subcommand"),
     }
     Ok(())
+}
+
+fn build_account_recover_args(
+    account_name: &str,
+    owner_email: &str,
+    code: Option<&str>,
+) -> Result<Value> {
+    let mut args = json!({"account_name": account_name, "owner_email": owner_email});
+    if let Some(code) = code {
+        let c = code.trim();
+        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
+            return Err(anyhow!(
+                "Invalid recovery code format. Expected a 6-digit numeric code."
+            ));
+        }
+        args["code"] = json!(c);
+    }
+    Ok(args)
+}
+
+fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({"owner_email": owner_email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
 }
 
 async fn run_proxy(endpoint: String) -> Result<()> {
@@ -7595,6 +7609,93 @@ mod tests {
         );
         let err = result.err().unwrap();
         assert!(err.to_string().contains("--body-file"));
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_owner_email_and_email_aliases() {
+        for flag in ["--owner-email", "--owner_email", "--email"] {
+            let cli = Cli::try_parse_from([
+                "inboxapi",
+                "verify-owner",
+                flag,
+                "owner@example.com",
+                "--code",
+                "123456",
+            ])
+            .unwrap();
+
+            match cli.command {
+                Some(Commands::VerifyOwner { owner_email, code }) => {
+                    assert_eq!(owner_email, "owner@example.com");
+                    assert_eq!(code.as_deref(), Some("123456"));
+                }
+                other => panic!(
+                    "expected VerifyOwner command, got {:?}",
+                    other.map(|_| "other")
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_verify_owner_args_use_api_field_names() {
+        let args = build_verify_owner_args("owner@example.com", Some("123456"));
+
+        assert_eq!(
+            args,
+            json!({"owner_email": "owner@example.com", "code": "123456"})
+        );
+        assert!(args.get("email").is_none());
+    }
+
+    #[test]
+    fn test_account_recover_accepts_specific_flags_and_aliases() {
+        let cases = [
+            ("--account-name", "--owner-email"),
+            ("--name", "--email"),
+            ("--name", "--owner_email"),
+        ];
+
+        for (name_flag, email_flag) in cases {
+            let cli = Cli::try_parse_from([
+                "inboxapi",
+                "account-recover",
+                name_flag,
+                "agent-name",
+                email_flag,
+                "owner@example.com",
+            ])
+            .unwrap();
+
+            match cli.command {
+                Some(Commands::AccountRecover {
+                    account_name,
+                    owner_email,
+                    code,
+                }) => {
+                    assert_eq!(account_name, "agent-name");
+                    assert_eq!(owner_email, "owner@example.com");
+                    assert!(code.is_none());
+                }
+                other => panic!(
+                    "expected AccountRecover command, got {:?}",
+                    other.map(|_| "other")
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_account_recover_args_use_api_field_names() {
+        let args = build_account_recover_args("agent-name", "owner@example.com", Some(" 123456 "))
+            .unwrap();
+
+        assert_eq!(
+            args,
+            json!({"account_name": "agent-name", "owner_email": "owner@example.com", "code": "123456"})
+        );
+        assert!(args.get("name").is_none());
+        assert!(args.get("email").is_none());
     }
 
     // --- guess_content_type tests ---


### PR DESCRIPTION
## Summary
- Map verify-owner requests to the API's owner_email field while keeping --email as a backwards-compatible alias
- Add --owner-email/--owner_email support for verify-owner and account-recover
- Align account-recover payloads with account_name/owner_email and cover both commands with parser/payload tests

Fixes #52.

## Validation
- cargo fmt
- cargo clippy -- -D warnings
- cargo test -- --test-threads=1
- cargo test rewrite_tools_list_preserves_other_tools -- --nocapture

Note: a default parallel cargo test run exposed an existing environment-variable race in rewrite_tools_list_preserves_other_tools; the test passes in isolation and the suite passes single-threaded.