### PR TITLE
Fix verify-owner owner_email payload

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7606,15 +7606,23 @@ mod tests {
     fn test_verify_owner_accepts_email_aliases() {
         for flag in ["--email", "--owner-email", "--owner_email"] {
             let cli = Cli::try_parse_from(["inboxapi", "verify-owner", flag, "user@example.com"])
-                .unwrap();
+                .unwrap_or_else(|err| {
+                    panic!("verify-owner should parse {flag} alias: {err}");
+                });
 
             match cli.command {
                 Some(Commands::VerifyOwner { email, code }) => {
-                    assert_eq!(email, "user@example.com");
-                    assert!(code.is_none());
+                    assert_eq!(
+                        email, "user@example.com",
+                        "verify-owner should assign email from {flag}"
+                    );
+                    assert!(
+                        code.is_none(),
+                        "verify-owner should leave code empty when omitted for {flag}"
+                    );
                 }
                 other => panic!(
-                    "expected VerifyOwner command, got {:?}",
+                    "expected VerifyOwner command for {flag}, got {:?}",
                     other.map(|_| "other")
                 ),
             }
@@ -7626,9 +7634,18 @@ mod tests {
         let code = "123456".to_string();
         let args = build_verify_owner_args("user@example.com", Some(&code));
 
-        assert_eq!(args["owner_email"], "user@example.com");
-        assert_eq!(args["code"], "123456");
-        assert!(args.get("email").is_none());
+        assert_eq!(
+            args["owner_email"], "user@example.com",
+            "verify_owner payload should use owner_email"
+        );
+        assert_eq!(
+            args["code"], "123456",
+            "verify_owner payload should include provided code"
+        );
+        assert!(
+            args.get("email").is_none(),
+            "verify_owner payload should not include legacy email key"
+        );
     }
 
     // --- guess_content_type tests ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,7 +302,7 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
+        #[arg(long, alias = "owner-email", alias = "owner_email")]
         email: String,
         /// Verification code (if already received)
         #[arg(long)]
@@ -1875,6 +1875,14 @@ fn build_send_email_args(
     args
 }
 
+fn build_verify_owner_args(email: &str, code: Option<&String>) -> Value {
+    let mut args = json!({"owner_email": email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
+}
+
 fn resolve_body_input(
     inline: Option<&str>,
     file: Option<&Path>,
@@ -2702,10 +2710,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(email, code.as_ref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7595,6 +7600,35 @@ mod tests {
         );
         let err = result.err().unwrap();
         assert!(err.to_string().contains("--body-file"));
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_email_aliases() {
+        for flag in ["--email", "--owner-email", "--owner_email"] {
+            let cli = Cli::try_parse_from(["inboxapi", "verify-owner", flag, "user@example.com"])
+                .unwrap();
+
+            match cli.command {
+                Some(Commands::VerifyOwner { email, code }) => {
+                    assert_eq!(email, "user@example.com");
+                    assert!(code.is_none());
+                }
+                other => panic!(
+                    "expected VerifyOwner command, got {:?}",
+                    other.map(|_| "other")
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_build_verify_owner_args_uses_owner_email_key() {
+        let code = "123456".to_string();
+        let args = build_verify_owner_args("user@example.com", Some(&code));
+
+        assert_eq!(args["owner_email"], "user@example.com");
+        assert_eq!(args["code"], "123456");
+        assert!(args.get("email").is_none());
     }
 
     // --- guess_content_type tests ---


### PR DESCRIPTION
## Summary
- map `verify-owner` CLI requests to the API's expected `owner_email` parameter
- keep `--email` working and accept `--owner-email` / `--owner_email` aliases
- add regression coverage for argument aliases and payload construction

Fixes #52.

## Validation
- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `target/debug/inboxapi-cli verify-owner --help`
- `printf 'n\n' | target/debug/inboxapi-cli verify-owner --email user@example.com`
- `printf 'n\n' | target/debug/inboxapi-cli verify-owner --owner-email user@example.com`

## Risks / rollback
Low-risk CLI argument/payload mapping change. Roll back by reverting this commit if the API contract changes.