### PR TITLE
[codex] Fix owner verification payload fields

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -290,11 +290,11 @@ enum Commands {
     /// Recover a lost account
     AccountRecover {
         /// Account name
-        #[arg(long)]
-        name: String,
+        #[arg(long = "account-name", alias = "name", alias = "account_name")]
+        account_name: String,
         /// Recovery email address
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", alias = "email", alias = "owner_email")]
+        owner_email: String,
         /// Recovery code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -302,8 +302,8 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", alias = "email", alias = "owner_email")]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -1875,6 +1875,38 @@ fn build_send_email_args(
     args
 }
 
+fn validate_six_digit_code(code: &str, label: &str) -> Result<String> {
+    let code = code.trim();
+    if code.len() == 6 && code.chars().all(|ch| ch.is_ascii_digit()) {
+        Ok(code.to_string())
+    } else {
+        Err(anyhow!(
+            "Invalid {} code format. Expected a 6-digit numeric code.",
+            label
+        ))
+    }
+}
+
+fn build_account_recover_args(
+    account_name: &str,
+    owner_email: &str,
+    code: Option<&str>,
+) -> Result<Value> {
+    let mut args = json!({"account_name": account_name, "owner_email": owner_email});
+    if let Some(code) = code {
+        args["code"] = json!(validate_six_digit_code(code, "recovery")?);
+    }
+    Ok(args)
+}
+
+fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({"owner_email": owner_email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
+}
+
 fn resolve_body_input(
     inline: Option<&str>,
     file: Option<&Path>,
@@ -2672,40 +2704,28 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             .await?;
         }
         Some(Commands::AccountRecover {
-            ref name,
-            ref email,
+            ref account_name,
+            ref owner_email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
-            if let Some(code) = code {
-                let c = code.trim();
-                if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-                    return Err(anyhow!(
-                        "Invalid recovery code format. Expected a 6-digit numeric code."
-                    ));
-                }
-                args["code"] = json!(c);
-            }
+            let args = build_account_recover_args(account_name, owner_email, code.as_deref())?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
             let text = extract_tool_result_text(&response)?;
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(owner_email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7574,6 +7594,125 @@ mod tests {
                 other.map(|_| "other")
             ),
         }
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_owner_email_flag() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--owner-email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner { owner_email, code }) => {
+                assert_eq!(owner_email, "owner@example.com");
+                assert!(code.is_none());
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_legacy_email_flag() {
+        let cli = Cli::try_parse_from(["inboxapi", "verify-owner", "--email", "owner@example.com"])
+            .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner { owner_email, .. }) => {
+                assert_eq!(owner_email, "owner@example.com");
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_underscore_owner_email_alias() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--owner_email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner { owner_email, .. }) => {
+                assert_eq!(owner_email, "owner@example.com");
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_account_recover_accepts_new_and_legacy_flags() {
+        let new_flags = Cli::try_parse_from([
+            "inboxapi",
+            "account-recover",
+            "--account-name",
+            "my-agent",
+            "--owner-email",
+            "owner@example.com",
+        ])
+        .unwrap();
+        let legacy_flags = Cli::try_parse_from([
+            "inboxapi",
+            "account-recover",
+            "--name",
+            "my-agent",
+            "--email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        for cli in [new_flags, legacy_flags] {
+            match cli.command {
+                Some(Commands::AccountRecover {
+                    account_name,
+                    owner_email,
+                    ..
+                }) => {
+                    assert_eq!(account_name, "my-agent");
+                    assert_eq!(owner_email, "owner@example.com");
+                }
+                other => panic!(
+                    "expected AccountRecover command, got {:?}",
+                    other.map(|_| "other")
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_verify_owner_args_use_api_field_names() {
+        let args = build_verify_owner_args("owner@example.com", Some("123456"));
+
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "123456");
+        assert!(args["email"].is_null());
+    }
+
+    #[test]
+    fn test_account_recover_args_use_api_field_names() {
+        let args =
+            build_account_recover_args("my-agent", "owner@example.com", Some("123456")).unwrap();
+
+        assert_eq!(args["account_name"], "my-agent");
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "123456");
+        assert!(args["name"].is_null());
+        assert!(args["email"].is_null());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix `verify-owner` so the CLI sends `owner_email` to the API instead of `email`.
- Add `--owner-email` and `--owner_email` while keeping the existing `--email` flag as a compatibility alias.
- Align `account-recover` with the same API field names: `account_name` and `owner_email`, while preserving `--name` and `--email` aliases.
- Add focused parser and payload-shape tests for both commands.

Fixes #52.

## Validation

- `cargo fmt --check`
- `cargo test verify_owner`
- `cargo test account_recover`
- `cargo clippy -- -D warnings`
- `cargo test`

## Rollback

Revert this commit. The only behavior change is CLI argument mapping for owner verification and account recovery payload construction.
