### PR TITLE
[codex] fix owner verification CLI payloads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5467,14 +5467,28 @@ mod tests {
             "blocked tool should be removed"
         );
         // get_emails now has untrusted content warning prepended
-        let get_emails_desc = tools[0]["description"].as_str().unwrap();
+        let get_emails_desc = tools
+            .iter()
+            .find(|t| t["name"].as_str() == Some("get_emails"))
+            .and_then(|t| t["description"].as_str())
+            .unwrap();
         assert!(
             get_emails_desc.starts_with(UNTRUSTED_CONTENT_WARNING),
             "get_emails should have untrusted warning"
         );
         assert!(get_emails_desc.contains("Fetch emails from your inbox"));
-        assert_eq!(tools[1]["description"], "Show help text");
-        assert_eq!(tools[2]["description"], AUTH_TOOL_OVERRIDE); // account_create
+        let help_desc = tools
+            .iter()
+            .find(|t| t["name"].as_str() == Some("help"))
+            .and_then(|t| t["description"].as_str())
+            .unwrap();
+        assert_eq!(help_desc, "Show help text");
+        let account_create_desc = tools
+            .iter()
+            .find(|t| t["name"].as_str() == Some("account_create"))
+            .and_then(|t| t["description"].as_str())
+            .unwrap();
+        assert_eq!(account_create_desc, AUTH_TOOL_OVERRIDE);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4928,6 +4928,7 @@ fn verify_hashcash(stamp: &str, expected_bits: u32) -> bool {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::sync::{Mutex, MutexGuard};
 
     fn make_creds(token: &str) -> Credentials {
         Credentials {
@@ -5388,16 +5389,24 @@ mod tests {
 
     // --- rewrite_tools_list tests ---
 
+    static EXPOSE_INTERNAL_TOOLS_LOCK: Mutex<()> = Mutex::new(());
+
     struct EnvVarGuard {
+        _lock: MutexGuard<'static, ()>,
         key: &'static str,
         prev: Option<String>,
     }
 
     impl EnvVarGuard {
         fn set(key: &'static str, value: &str) -> Self {
+            let lock = EXPOSE_INTERNAL_TOOLS_LOCK.lock().unwrap();
             let prev = std::env::var(key).ok();
             std::env::set_var(key, value);
-            Self { key, prev }
+            Self {
+                _lock: lock,
+                key,
+                prev,
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,12 @@ fn account_recover_args(account_name: &str, owner_email: &str) -> Value {
     json!({"account_name": account_name, "owner_email": owner_email})
 }
 
-fn verify_owner_args(owner_email: &str) -> Value {
-    json!({"owner_email": owner_email})
+fn verify_owner_args(owner_email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({"owner_email": owner_email});
+    if let Some(code) = code {
+        args["code"] = json!(code.trim());
+    }
+    args
 }
 
 #[derive(Parser)]
@@ -2710,10 +2714,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = verify_owner_args(owner_email);
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = verify_owner_args(owner_email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7754,9 +7755,14 @@ mod tests {
     #[test]
     fn test_owner_tool_payload_keys_match_api_schema() {
         assert_eq!(
-            verify_owner_args("owner@example.com"),
+            verify_owner_args("owner@example.com", None),
             json!({"owner_email": "owner@example.com"}),
             "verify_owner payload should use the API schema owner_email key"
+        );
+        assert_eq!(
+            verify_owner_args("owner@example.com", Some(" 654321 ")),
+            json!({"owner_email": "owner@example.com", "code": "654321"}),
+            "verify_owner payload should trim the verification code"
         );
         assert_eq!(
             account_recover_args("agent-name", "owner@example.com"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,14 @@ const MAX_BODY_FILE_BYTES: u64 = 20 * 1024 * 1024;
 /// Maximum size of an attachment download (100MB) to prevent memory exhaustion.
 const MAX_ATTACHMENT_DOWNLOAD_BYTES: u64 = 100 * 1024 * 1024;
 
+fn account_recover_args(account_name: &str, owner_email: &str) -> Value {
+    json!({"account_name": account_name, "owner_email": owner_email})
+}
+
+fn verify_owner_args(owner_email: &str) -> Value {
+    json!({"owner_email": owner_email})
+}
+
 #[derive(Parser)]
 #[command(name = "inboxapi", bin_name = "inboxapi")]
 #[command(version)]
@@ -290,11 +298,11 @@ enum Commands {
     /// Recover a lost account
     AccountRecover {
         /// Account name
-        #[arg(long)]
-        name: String,
+        #[arg(long, alias = "name")]
+        account_name: String,
         /// Recovery email address
-        #[arg(long)]
-        email: String,
+        #[arg(long, alias = "email")]
+        owner_email: String,
         /// Recovery code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -302,8 +310,8 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
-        email: String,
+        #[arg(long, alias = "email")]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -2672,11 +2680,11 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             .await?;
         }
         Some(Commands::AccountRecover {
-            ref name,
-            ref email,
+            ref account_name,
+            ref owner_email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
+            let mut args = account_recover_args(account_name, owner_email);
             if let Some(code) = code {
                 let c = code.trim();
                 if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
@@ -2692,17 +2700,17 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
+            let mut args = verify_owner_args(owner_email);
             if let Some(code) = code {
                 args["code"] = json!(code);
             }
@@ -7595,6 +7603,118 @@ mod tests {
         );
         let err = result.err().unwrap();
         assert!(err.to_string().contains("--body-file"));
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_owner_email_and_email_alias() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--owner-email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner { owner_email, code }) => {
+                assert_eq!(owner_email, "owner@example.com");
+                assert!(code.is_none());
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--email",
+            "owner@example.com",
+            "--code",
+            "123456",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner { owner_email, code }) => {
+                assert_eq!(owner_email, "owner@example.com");
+                assert_eq!(code.as_deref(), Some("123456"));
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_account_recover_accepts_schema_names_and_legacy_aliases() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "account-recover",
+            "--account-name",
+            "agent-name",
+            "--owner-email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::AccountRecover {
+                account_name,
+                owner_email,
+                code,
+            }) => {
+                assert_eq!(account_name, "agent-name");
+                assert_eq!(owner_email, "owner@example.com");
+                assert!(code.is_none());
+            }
+            other => panic!(
+                "expected AccountRecover command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "account-recover",
+            "--name",
+            "agent-name",
+            "--email",
+            "owner@example.com",
+            "--code",
+            "123456",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::AccountRecover {
+                account_name,
+                owner_email,
+                code,
+            }) => {
+                assert_eq!(account_name, "agent-name");
+                assert_eq!(owner_email, "owner@example.com");
+                assert_eq!(code.as_deref(), Some("123456"));
+            }
+            other => panic!(
+                "expected AccountRecover command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_owner_tool_payload_keys_match_api_schema() {
+        assert_eq!(
+            verify_owner_args("owner@example.com"),
+            json!({"owner_email": "owner@example.com"})
+        );
+        assert_eq!(
+            account_recover_args("agent-name", "owner@example.com"),
+            json!({"account_name": "agent-name", "owner_email": "owner@example.com"})
+        );
     }
 
     // --- guess_content_type tests ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -7617,8 +7617,14 @@ mod tests {
 
         match cli.command {
             Some(Commands::VerifyOwner { owner_email, code }) => {
-                assert_eq!(owner_email, "owner@example.com");
-                assert!(code.is_none());
+                assert_eq!(
+                    owner_email, "owner@example.com",
+                    "owner_email should be populated from --owner-email"
+                );
+                assert!(
+                    code.is_none(),
+                    "code should be absent when --code is not provided"
+                );
             }
             other => panic!(
                 "expected VerifyOwner command, got {:?}",
@@ -7638,8 +7644,15 @@ mod tests {
 
         match cli.command {
             Some(Commands::VerifyOwner { owner_email, code }) => {
-                assert_eq!(owner_email, "owner@example.com");
-                assert_eq!(code.as_deref(), Some("123456"));
+                assert_eq!(
+                    owner_email, "owner@example.com",
+                    "owner_email should be populated from the legacy --email alias"
+                );
+                assert_eq!(
+                    code.as_deref(),
+                    Some("123456"),
+                    "code should be populated from --code"
+                );
             }
             other => panic!(
                 "expected VerifyOwner command, got {:?}",
@@ -7666,9 +7679,18 @@ mod tests {
                 owner_email,
                 code,
             }) => {
-                assert_eq!(account_name, "agent-name");
-                assert_eq!(owner_email, "owner@example.com");
-                assert!(code.is_none());
+                assert_eq!(
+                    account_name, "agent-name",
+                    "account_name should be populated from --account-name"
+                );
+                assert_eq!(
+                    owner_email, "owner@example.com",
+                    "owner_email should be populated from --owner-email"
+                );
+                assert!(
+                    code.is_none(),
+                    "code should be absent when --code is not provided"
+                );
             }
             other => panic!(
                 "expected AccountRecover command, got {:?}",
@@ -7694,9 +7716,19 @@ mod tests {
                 owner_email,
                 code,
             }) => {
-                assert_eq!(account_name, "agent-name");
-                assert_eq!(owner_email, "owner@example.com");
-                assert_eq!(code.as_deref(), Some("123456"));
+                assert_eq!(
+                    account_name, "agent-name",
+                    "account_name should be populated from the legacy --name alias"
+                );
+                assert_eq!(
+                    owner_email, "owner@example.com",
+                    "owner_email should be populated from the legacy --email alias"
+                );
+                assert_eq!(
+                    code.as_deref(),
+                    Some("123456"),
+                    "code should be populated from --code"
+                );
             }
             other => panic!(
                 "expected AccountRecover command, got {:?}",
@@ -7709,11 +7741,13 @@ mod tests {
     fn test_owner_tool_payload_keys_match_api_schema() {
         assert_eq!(
             verify_owner_args("owner@example.com"),
-            json!({"owner_email": "owner@example.com"})
+            json!({"owner_email": "owner@example.com"}),
+            "verify_owner payload should use the API schema owner_email key"
         );
         assert_eq!(
             account_recover_args("agent-name", "owner@example.com"),
-            json!({"account_name": "agent-name", "owner_email": "owner@example.com"})
+            json!({"account_name": "agent-name", "owner_email": "owner@example.com"}),
+            "account_recover payload should use the API schema keys"
         );
     }
 


### PR DESCRIPTION
## Summary
- map `verify-owner` payloads to the API schema key `owner_email`
- expose `--owner-email` while preserving `--email` as a CLI alias
- align `account-recover` with `account_name` and `owner_email`, preserving legacy aliases
- add parser and payload-key unit coverage for both owner flows

## Root Cause
The CLI used friendly local field names (`email`, and for recovery `name`) directly as JSON payload keys. The MCP/API schemas expect `owner_email` for owner verification and `account_name`/`owner_email` for recovery, so requests failed deserialization before reaching the tool logic.

## Validation
- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo run --quiet -- verify-owner --help`
- `cargo run --quiet -- account-recover --help`

Fixes #52
