### PR TITLE
[codex] fix verify-owner owner email payload

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -302,8 +302,8 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", visible_aliases = ["email", "owner_email"])]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -534,6 +534,28 @@ fn prompt_yes_no(prompt: &str) -> bool {
         return false;
     }
     matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
+}
+
+fn account_recover_args(name: &str, email: &str, code: Option<&str>) -> Result<Value> {
+    let mut args = json!({"account_name": name, "owner_email": email});
+    if let Some(code) = code {
+        let c = code.trim();
+        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
+            return Err(anyhow!(
+                "Invalid recovery code format. Expected a 6-digit numeric code."
+            ));
+        }
+        args["code"] = json!(c);
+    }
+    Ok(args)
+}
+
+fn verify_owner_args(owner_email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({"owner_email": owner_email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
 }
 
 fn prompt_line(prompt: &str) -> Result<String> {
@@ -2676,36 +2698,24 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             ref email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
-            if let Some(code) = code {
-                let c = code.trim();
-                if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-                    return Err(anyhow!(
-                        "Invalid recovery code format. Expected a 6-digit numeric code."
-                    ));
-                }
-                args["code"] = json!(c);
-            }
+            let args = account_recover_args(name, email, code.as_deref())?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
             let text = extract_tool_result_text(&response)?;
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = verify_owner_args(owner_email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -4943,6 +4953,49 @@ mod tests {
                 "arguments": arguments
             }
         })
+    }
+
+    #[test]
+    fn verify_owner_parses_owner_email_and_email_aliases() {
+        for flag in ["--owner-email", "--email", "--owner_email"] {
+            let cli = Cli::try_parse_from(["inboxapi", "verify-owner", flag, "owner@example.com"])
+                .unwrap();
+
+            match cli.command.unwrap() {
+                Commands::VerifyOwner { owner_email, code } => {
+                    assert_eq!(owner_email, "owner@example.com");
+                    assert_eq!(code, None);
+                }
+                _ => panic!("expected verify-owner command"),
+            }
+        }
+    }
+
+    #[test]
+    fn verify_owner_args_uses_owner_email_key() {
+        let args = verify_owner_args("owner@example.com", Some("123456"));
+
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "123456");
+        assert!(args["email"].is_null());
+    }
+
+    #[test]
+    fn account_recover_args_uses_api_schema_keys() {
+        let args =
+            account_recover_args("test-account", "owner@example.com", Some(" 123456 ")).unwrap();
+
+        assert_eq!(args["account_name"], "test-account");
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "123456");
+        assert!(args["name"].is_null());
+        assert!(args["email"].is_null());
+    }
+
+    #[test]
+    fn account_recover_args_rejects_invalid_codes() {
+        assert!(account_recover_args("test-account", "owner@example.com", Some("12345")).is_err());
+        assert!(account_recover_args("test-account", "owner@example.com", Some("abcdef")).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #52.

## What changed

- `verify-owner` now sends `owner_email` to the MCP API instead of `email`.

- The command now exposes `--owner-email` while keeping `--email` and `--owner_email` as aliases for compatibility.
- `account-recover` now builds the API payload with `account_name` and `owner_email`, matching the existing API schema expectation.



## Validation

- `cargo fmt`
- `cargo test`

- `cargo clippy -- -D warnings`



## Risk and rollback
Low-risk CLI request-shape fix. Rollback is reverting this commit if the API contract differs from the documented schema.






