### PR TITLE
Fix verify-owner owner_email payload

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -290,11 +290,11 @@ enum Commands {
     /// Recover a lost account
     AccountRecover {
         /// Account name
-        #[arg(long)]
-        name: String,
+        #[arg(long = "name", alias = "account-name", alias = "account_name")]
+        account_name: String,
         /// Recovery email address
-        #[arg(long)]
-        email: String,
+        #[arg(long = "email", alias = "owner-email", alias = "owner_email")]
+        owner_email: String,
         /// Recovery code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -302,8 +302,8 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", alias = "email", alias = "owner_email")]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -1875,6 +1875,32 @@ fn build_send_email_args(
     args
 }
 
+fn build_account_recover_args(
+    account_name: &str,
+    owner_email: &str,
+    code: Option<&str>,
+) -> Result<Value> {
+    let mut args = json!({"account_name": account_name, "owner_email": owner_email});
+    if let Some(code) = code {
+        let c = code.trim();
+        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
+            return Err(anyhow!(
+                "Invalid recovery code format. Expected a 6-digit numeric code."
+            ));
+        }
+        args["code"] = json!(c);
+    }
+    Ok(args)
+}
+
+fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({"owner_email": owner_email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
+}
+
 fn resolve_body_input(
     inline: Option<&str>,
     file: Option<&Path>,
@@ -2672,40 +2698,28 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             .await?;
         }
         Some(Commands::AccountRecover {
-            ref name,
-            ref email,
+            ref account_name,
+            ref owner_email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
-            if let Some(code) = code {
-                let c = code.trim();
-                if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-                    return Err(anyhow!(
-                        "Invalid recovery code format. Expected a 6-digit numeric code."
-                    ));
-                }
-                args["code"] = json!(c);
-            }
+            let args = build_account_recover_args(account_name, owner_email, code.as_deref())?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
             let text = extract_tool_result_text(&response)?;
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(owner_email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7577,6 +7591,52 @@ mod tests {
     }
 
     #[test]
+    fn test_verify_owner_accepts_legacy_email_flag() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--email",
+            "owner@example.com",
+            "--code",
+            "123456",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner { owner_email, code }) => {
+                assert_eq!(owner_email, "owner@example.com");
+                assert_eq!(code.as_deref(), Some("123456"));
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_owner_email_flag() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--owner-email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner { owner_email, code }) => {
+                assert_eq!(owner_email, "owner@example.com");
+                assert!(code.is_none());
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
     fn test_send_reply_rejects_body_and_body_file_together() {
         let result = Cli::try_parse_from([
             "inboxapi",
@@ -7716,6 +7776,35 @@ mod tests {
             vec![],
         );
         assert_eq!(args["to"], json!(["a@b.com", "c@d.com"]));
+    }
+
+    #[test]
+    fn test_verify_owner_args_use_owner_email_key() {
+        let args = build_verify_owner_args("owner@example.com", Some("123456"));
+
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "123456");
+        assert!(args.get("email").is_none());
+    }
+
+    #[test]
+    fn test_account_recover_args_use_api_field_names() {
+        let args = build_account_recover_args("test-agent", "owner@example.com", Some(" 123456 "))
+            .unwrap();
+
+        assert_eq!(args["account_name"], "test-agent");
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "123456");
+        assert!(args.get("name").is_none());
+        assert!(args.get("email").is_none());
+    }
+
+    #[test]
+    fn test_account_recover_args_reject_invalid_code() {
+        let err = build_account_recover_args("test-agent", "owner@example.com", Some("abc123"))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Invalid recovery code format"));
     }
 
     // --- build_attachment_from_file tests ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,10 +290,10 @@ enum Commands {
     /// Recover a lost account
     AccountRecover {
         /// Account name
-        #[arg(long = "name", alias = "account-name", alias = "account_name")]
+        #[arg(long = "account-name", alias = "name", alias = "account_name")]
         account_name: String,
         /// Recovery email address
-        #[arg(long = "email", alias = "owner-email", alias = "owner_email")]
+        #[arg(long = "owner-email", alias = "email", alias = "owner_email")]
         owner_email: String,
         /// Recovery code (if already received)
         #[arg(long)]
@@ -1893,12 +1893,18 @@ fn build_account_recover_args(
     Ok(args)
 }
 
-fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Value {
+fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Result<Value> {
     let mut args = json!({"owner_email": owner_email});
     if let Some(code) = code {
-        args["code"] = json!(code);
+        let c = code.trim();
+        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
+            return Err(anyhow!(
+                "Invalid verification code format. Expected a 6-digit numeric code."
+            ));
+        }
+        args["code"] = json!(c);
     }
-    args
+    Ok(args)
 }
 
 fn resolve_body_input(
@@ -2719,7 +2725,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
                 println!("Aborted.");
                 return Ok(());
             }
-            let args = build_verify_owner_args(owner_email, code.as_deref());
+            let args = build_verify_owner_args(owner_email, code.as_deref())?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7780,11 +7786,18 @@ mod tests {
 
     #[test]
     fn test_verify_owner_args_use_owner_email_key() {
-        let args = build_verify_owner_args("owner@example.com", Some("123456"));
+        let args = build_verify_owner_args("owner@example.com", Some(" 123456 ")).unwrap();
 
         assert_eq!(args["owner_email"], "owner@example.com");
         assert_eq!(args["code"], "123456");
         assert!(args.get("email").is_none());
+    }
+
+    #[test]
+    fn test_verify_owner_args_reject_invalid_code() {
+        let err = build_verify_owner_args("owner@example.com", Some("abc123")).unwrap_err();
+
+        assert!(err.to_string().contains("Invalid verification code format"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- map `verify-owner` CLI input to the API `owner_email` field
- keep legacy `--email` working and add `--owner-email` / `--owner_email` aliases
- align `account-recover` payload with API-style `account_name` and `owner_email` fields while keeping legacy flags
- add parser and payload tests for the field mapping

## Tests
- `cargo fmt --check`
- `cargo test verify_owner`
- `cargo test account_recover`
- `cargo test`
- `cargo clippy -- -D warnings`

## Risk / rollback
- Low risk; CLI flag aliases preserve old usage while correcting API payload keys.
- Rollback: revert commit `78282c1` if API compatibility issues appear.

Closes #52