### PR TITLE
[codex] Fix owner email CLI payloads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -293,8 +293,8 @@ enum Commands {
         #[arg(long)]
         name: String,
         /// Recovery email address
-        #[arg(long)]
-        email: String,
+        #[arg(long = "email", visible_alias = "owner-email", alias = "owner_email")]
+        owner_email: String,
         /// Recovery code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -302,8 +302,8 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", visible_alias = "email", alias = "owner_email")]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -2673,39 +2673,27 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
         }
         Some(Commands::AccountRecover {
             ref name,
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
-            if let Some(code) = code {
-                let c = code.trim();
-                if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-                    return Err(anyhow!(
-                        "Invalid recovery code format. Expected a 6-digit numeric code."
-                    ));
-                }
-                args["code"] = json!(c);
-            }
+            let args = build_account_recover_args(name, owner_email, code.as_deref())?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
             let text = extract_tool_result_text(&response)?;
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(owner_email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -3469,6 +3457,28 @@ fn inject_rate_limit_warning(response: &mut Value, retry_after: u64) {
             }
         }
     }
+}
+
+fn build_account_recover_args(name: &str, owner_email: &str, code: Option<&str>) -> Result<Value> {
+    let mut args = json!({"account_name": name, "owner_email": owner_email});
+    if let Some(code) = code {
+        let c = code.trim();
+        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
+            return Err(anyhow!(
+                "Invalid recovery code format. Expected a 6-digit numeric code."
+            ));
+        }
+        args["code"] = json!(c);
+    }
+    Ok(args)
+}
+
+fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({"owner_email": owner_email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
 }
 
 fn is_token_expired_error(response: &Value) -> bool {
@@ -5062,6 +5072,27 @@ mod tests {
         inject_token(&mut msg, &make_creds("test-token"));
 
         assert!(msg["params"]["arguments"]["token"].is_null());
+    }
+
+    #[test]
+    fn account_recover_args_use_api_field_names() {
+        let args =
+            build_account_recover_args("test", "owner@example.com", Some(" 123456 ")).unwrap();
+
+        assert_eq!(args["account_name"], "test");
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "123456");
+        assert!(args["name"].is_null());
+        assert!(args["email"].is_null());
+    }
+
+    #[test]
+    fn verify_owner_args_use_owner_email_field() {
+        let args = build_verify_owner_args("owner@example.com", Some("123456"));
+
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "123456");
+        assert!(args["email"].is_null());
     }
 
     #[test]
@@ -7595,6 +7626,56 @@ mod tests {
         );
         let err = result.err().unwrap();
         assert!(err.to_string().contains("--body-file"));
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_owner_email_flag() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--owner-email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner {
+                owner_email, code, ..
+            }) => {
+                assert_eq!(owner_email, "owner@example.com");
+                assert!(code.is_none());
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_verify_owner_keeps_email_alias() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--email",
+            "owner@example.com",
+            "--code",
+            "123456",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner {
+                owner_email, code, ..
+            }) => {
+                assert_eq!(owner_email, "owner@example.com");
+                assert_eq!(code.as_deref(), Some("123456"));
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
     }
 
     // --- guess_content_type tests ---


### PR DESCRIPTION
## Summary

- Fix `verify-owner` to send `owner_email` to the API instead of `email`.
- Add `--owner-email` as the canonical `verify-owner` flag while keeping `--email` and `--owner_email` as aliases.
- Fix `account-recover` to send `account_name` and `owner_email`, matching the existing auth-tool tests and API naming.
- Add unit coverage for payload construction and `verify-owner` flag parsing.

## Root Cause

The CLI used user-facing flag names directly as MCP argument names. The API schema expects `owner_email` for owner verification and `account_name`/`owner_email` for recovery, so `verify-owner --email ...` produced an API deserialization error.

## Validation

- `cargo fmt -- --check`
- `cargo test verify_owner`
- `cargo test account_recover`
- `cargo clippy -- -D warnings`
- `cargo test -- --test-threads=1`

Note: a normal parallel `cargo test` run hit an unrelated environment-variable race in `rewrite_tools_list_preserves_tool_fields`; the same test passed in isolation, and the full suite passed single-threaded.

## Rollback

Revert this PR. The CLI would return to the previous behaviour where `verify-owner` sends `email` and the API rejects the request.

Closes #52
