### PR TITLE
[codex] Fix owner verification CLI payload

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -290,11 +290,11 @@ enum Commands {
     /// Recover a lost account
     AccountRecover {
         /// Account name
-        #[arg(long)]
-        name: String,
+        #[arg(long = "account-name", alias = "name")]
+        account_name: String,
         /// Recovery email address
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", aliases = ["email", "owner_email"])]
+        owner_email: String,
         /// Recovery code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -302,8 +302,8 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", aliases = ["email", "owner_email"])]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -1875,6 +1875,32 @@ fn build_send_email_args(
     args
 }
 
+fn build_account_recover_args(
+    account_name: &str,
+    owner_email: &str,
+    code: &Option<String>,
+) -> Result<Value> {
+    let mut args = json!({"account_name": account_name, "owner_email": owner_email});
+    if let Some(code) = code {
+        let c = code.trim();
+        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
+            return Err(anyhow!(
+                "Invalid recovery code format. Expected a 6-digit numeric code."
+            ));
+        }
+        args["code"] = json!(c);
+    }
+    Ok(args)
+}
+
+fn build_verify_owner_args(owner_email: &str, code: &Option<String>) -> Value {
+    let mut args = json!({"owner_email": owner_email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
+}
+
 fn resolve_body_input(
     inline: Option<&str>,
     file: Option<&Path>,
@@ -2672,40 +2698,28 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             .await?;
         }
         Some(Commands::AccountRecover {
-            ref name,
-            ref email,
+            ref account_name,
+            ref owner_email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
-            if let Some(code) = code {
-                let c = code.trim();
-                if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-                    return Err(anyhow!(
-                        "Invalid recovery code format. Expected a 6-digit numeric code."
-                    ));
-                }
-                args["code"] = json!(c);
-            }
+            let args = build_account_recover_args(account_name, owner_email, code)?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
             let text = extract_tool_result_text(&response)?;
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(owner_email, code);
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7595,6 +7609,107 @@ mod tests {
         );
         let err = result.err().unwrap();
         assert!(err.to_string().contains("--body-file"));
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_owner_email_and_email_aliases() {
+        for flag in ["--owner-email", "--owner_email", "--email"] {
+            let cli = Cli::try_parse_from(["inboxapi", "verify-owner", flag, "owner@example.com"])
+                .unwrap();
+
+            match cli.command {
+                Some(Commands::VerifyOwner {
+                    owner_email, code, ..
+                }) => {
+                    assert_eq!(owner_email, "owner@example.com");
+                    assert!(code.is_none());
+                }
+                other => panic!(
+                    "expected VerifyOwner command, got {:?}",
+                    other.map(|_| "other")
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_build_verify_owner_args_uses_owner_email_key() {
+        let args = build_verify_owner_args("owner@example.com", &Some("123456".to_string()));
+
+        assert_eq!(
+            args,
+            json!({"owner_email": "owner@example.com", "code": "123456"})
+        );
+        assert!(args.get("email").is_none());
+    }
+
+    #[test]
+    fn test_account_recover_accepts_legacy_and_contract_flags() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "account-recover",
+            "--name",
+            "agent",
+            "--email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::AccountRecover {
+                account_name,
+                owner_email,
+                code,
+                ..
+            }) => {
+                assert_eq!(account_name, "agent");
+                assert_eq!(owner_email, "owner@example.com");
+                assert!(code.is_none());
+            }
+            other => panic!(
+                "expected AccountRecover command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "account-recover",
+            "--account-name",
+            "agent",
+            "--owner-email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::AccountRecover {
+                account_name,
+                owner_email,
+                ..
+            }) => {
+                assert_eq!(account_name, "agent");
+                assert_eq!(owner_email, "owner@example.com");
+            }
+            other => panic!(
+                "expected AccountRecover command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_build_account_recover_args_uses_api_keys() {
+        let args =
+            build_account_recover_args("agent", "owner@example.com", &Some(" 123456 ".to_string()))
+                .unwrap();
+
+        assert_eq!(
+            args,
+            json!({"account_name": "agent", "owner_email": "owner@example.com", "code": "123456"})
+        );
+        assert!(args.get("name").is_none());
+        assert!(args.get("email").is_none());
     }
 
     // --- guess_content_type tests ---


### PR DESCRIPTION
## Summary
- send `verify_owner` payloads with `owner_email` instead of `email`
- accept `--owner-email` / `--owner_email` while keeping `--email` as a backwards-compatible alias
- align `account-recover` CLI payloads to `account_name` / `owner_email` and keep legacy `--name` / `--email` aliases
- add focused CLI parsing and payload-shape tests

Fixes #52.

## Validation
- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`

## Risk / rollback
Low-risk CLI argument and payload mapping change. Roll back by reverting commit `3cad6ca` if the API contract is different than expected.