### PR TITLE
Fix owner verification CLI payloads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -290,10 +290,10 @@ enum Commands {
     /// Recover a lost account
     AccountRecover {
         /// Account name
-        #[arg(long)]
+        #[arg(long, alias = "account-name", alias = "account_name")]
         name: String,
         /// Recovery email address
-        #[arg(long)]
+        #[arg(long, alias = "owner-email", alias = "owner_email")]
         email: String,
         /// Recovery code (if already received)
         #[arg(long)]
@@ -302,7 +302,7 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
+        #[arg(long, alias = "owner-email", alias = "owner_email")]
         email: String,
         /// Verification code (if already received)
         #[arg(long)]
@@ -1875,6 +1875,28 @@ fn build_send_email_args(
     args
 }
 
+fn build_account_recover_args(name: &str, email: &str, code: Option<&str>) -> Result<Value> {
+    let mut args = json!({"account_name": name, "owner_email": email});
+    if let Some(code) = code {
+        let c = code.trim();
+        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
+            return Err(anyhow!(
+                "Invalid recovery code format. Expected a 6-digit numeric code."
+            ));
+        }
+        args["code"] = json!(c);
+    }
+    Ok(args)
+}
+
+fn build_verify_owner_args(email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({"owner_email": email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
+}
+
 fn resolve_body_input(
     inline: Option<&str>,
     file: Option<&Path>,
@@ -2676,16 +2698,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             ref email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
-            if let Some(code) = code {
-                let c = code.trim();
-                if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-                    return Err(anyhow!(
-                        "Invalid recovery code format. Expected a 6-digit numeric code."
-                    ));
-                }
-                args["code"] = json!(c);
-            }
+            let args = build_account_recover_args(name, email, code.as_deref())?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -2702,10 +2715,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7597,6 +7607,55 @@ mod tests {
         assert!(err.to_string().contains("--body-file"));
     }
 
+    #[test]
+    fn test_verify_owner_accepts_owner_email_alias() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--owner-email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner { email, code }) => {
+                assert_eq!(email, "owner@example.com");
+                assert!(code.is_none());
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_account_recover_accepts_schema_aliases() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "account-recover",
+            "--account-name",
+            "agent-name",
+            "--owner-email",
+            "owner@example.com",
+            "--code",
+            "123456",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::AccountRecover { name, email, code }) => {
+                assert_eq!(name, "agent-name");
+                assert_eq!(email, "owner@example.com");
+                assert_eq!(code.as_deref(), Some("123456"));
+            }
+            other => panic!(
+                "expected AccountRecover command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
     // --- guess_content_type tests ---
 
     #[test]
@@ -7620,6 +7679,37 @@ mod tests {
             guess_content_type(Path::new("file.xyz123")),
             "application/octet-stream"
         );
+    }
+
+    // --- owner verification/recovery args tests ---
+
+    #[test]
+    fn test_verify_owner_args_use_api_schema_names() {
+        let args = build_verify_owner_args("owner@example.com", Some("123456"));
+
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "123456");
+        assert!(args.get("email").is_none());
+    }
+
+    #[test]
+    fn test_account_recover_args_use_api_schema_names() {
+        let args = build_account_recover_args("agent-name", "owner@example.com", Some(" 123456 "))
+            .unwrap();
+
+        assert_eq!(args["account_name"], "agent-name");
+        assert_eq!(args["owner_email"], "owner@example.com");
+        assert_eq!(args["code"], "123456");
+        assert!(args.get("name").is_none());
+        assert!(args.get("email").is_none());
+    }
+
+    #[test]
+    fn test_account_recover_args_reject_invalid_code() {
+        let err = build_account_recover_args("agent-name", "owner@example.com", Some("ABC123"))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Invalid recovery code format"));
     }
 
     // --- build_send_email_args tests ---


### PR DESCRIPTION
## Summary
- send `owner_email` for `verify-owner` while keeping `--email` and accepting `--owner-email` aliases
- send `account_name`/`owner_email` for `account-recover` while keeping existing public flags and accepting schema aliases
- add parser and payload tests for owner verification/recovery

Fixes #52.

## Tests
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

## Risks / rollback
- Low risk: scoped to CLI argument-to-payload mapping for owner verification and recovery commands.
- Rollback: revert commit `8becef9` if the API contract differs unexpectedly.