### PR TITLE
[codex] Fix owner email payloads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -292,9 +292,9 @@ enum Commands {
         /// Account name
         #[arg(long)]
         name: String,
-        /// Recovery email address
-        #[arg(long)]
-        email: String,
+        /// Verified owner email address
+        #[arg(long = "owner-email", visible_alias = "email", alias = "owner_email")]
+        owner_email: String,
         /// Recovery code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -302,8 +302,8 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", visible_alias = "email", alias = "owner_email")]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -1875,6 +1875,28 @@ fn build_send_email_args(
     args
 }
 
+fn build_account_recover_args(name: &str, owner_email: &str, code: Option<&str>) -> Result<Value> {
+    let mut args = json!({"account_name": name, "owner_email": owner_email});
+    if let Some(code) = code {
+        let c = code.trim();
+        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
+            return Err(anyhow!(
+                "Invalid recovery code format. Expected a 6-digit numeric code."
+            ));
+        }
+        args["code"] = json!(c);
+    }
+    Ok(args)
+}
+
+fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({"owner_email": owner_email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
+}
+
 fn resolve_body_input(
     inline: Option<&str>,
     file: Option<&Path>,
@@ -2673,39 +2695,27 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
         }
         Some(Commands::AccountRecover {
             ref name,
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
-            if let Some(code) = code {
-                let c = code.trim();
-                if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-                    return Err(anyhow!(
-                        "Invalid recovery code format. Expected a 6-digit numeric code."
-                    ));
-                }
-                args["code"] = json!(c);
-            }
+            let args = build_account_recover_args(name, owner_email, code.as_deref())?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
             let text = extract_tool_result_text(&response)?;
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(owner_email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7574,6 +7584,116 @@ mod tests {
                 other.map(|_| "other")
             ),
         }
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_owner_email_flag() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--owner-email",
+            "owner@example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner {
+                owner_email, code, ..
+            }) => {
+                assert_eq!(owner_email, "owner@example.com");
+                assert!(code.is_none());
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_email_alias() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--email",
+            "owner@example.com",
+            "--code",
+            "123456",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::VerifyOwner {
+                owner_email, code, ..
+            }) => {
+                assert_eq!(owner_email, "owner@example.com");
+                assert_eq!(code.as_deref(), Some("123456"));
+            }
+            other => panic!(
+                "expected VerifyOwner command, got {:?}",
+                other.map(|_| "other")
+            ),
+        }
+    }
+
+    #[test]
+    fn test_account_recover_accepts_owner_email_aliases() {
+        for flag in ["--owner-email", "--owner_email", "--email"] {
+            let cli = Cli::try_parse_from([
+                "inboxapi",
+                "account-recover",
+                "--name",
+                "test-agent",
+                flag,
+                "owner@example.com",
+            ])
+            .unwrap();
+
+            match cli.command {
+                Some(Commands::AccountRecover {
+                    name,
+                    owner_email,
+                    code,
+                    ..
+                }) => {
+                    assert_eq!(name, "test-agent");
+                    assert_eq!(owner_email, "owner@example.com");
+                    assert!(code.is_none());
+                }
+                other => panic!(
+                    "expected AccountRecover command, got {:?}",
+                    other.map(|_| "other")
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_build_verify_owner_args_uses_owner_email_key() {
+        let args = build_verify_owner_args("owner@example.com", Some("123456"));
+
+        assert_eq!(
+            args,
+            json!({"owner_email": "owner@example.com", "code": "123456"})
+        );
+        assert!(args.get("email").is_none());
+    }
+
+    #[test]
+    fn test_build_account_recover_args_uses_api_keys() {
+        let args = build_account_recover_args("test-agent", "owner@example.com", Some(" 123456 "))
+            .unwrap();
+
+        assert_eq!(
+            args,
+            json!({
+                "account_name": "test-agent",
+                "owner_email": "owner@example.com",
+                "code": "123456"
+            })
+        );
+        assert!(args.get("name").is_none());
+        assert!(args.get("email").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Map `verify-owner` requests to the API `owner_email` key.
- Add `--owner-email` and `--owner_email` support while preserving `--email` as an alias.
- Map `account-recover` to `account_name` and `owner_email`, with tests for the payload shape.

## Root Cause

The CLI accepted an `email` argument and sent it as `email`, but the MCP API expects `owner_email` for owner verification. `account-recover` had the same naming mismatch risk for `name`/`email` versus the API keys.

Fixes #52.

## Validation

- `cargo test`
- `cargo clippy -- -D warnings`

## Rollback

Revert commit `021b3d7` if the API contract is intentionally different from the documented `owner_email`/`account_name` fields.
