### PR TITLE
Fix owner verification payload fields

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -290,11 +290,11 @@ enum Commands {
     /// Recover a lost account
     AccountRecover {
         /// Account name
-        #[arg(long)]
-        name: String,
+        #[arg(long = "account-name", visible_alias = "name", alias = "account_name")]
+        account_name: String,
         /// Recovery email address
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", visible_alias = "email", alias = "owner_email")]
+        owner_email: String,
         /// Recovery code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -302,8 +302,8 @@ enum Commands {
     /// Verify email ownership
     VerifyOwner {
         /// Email address to verify
-        #[arg(long)]
-        email: String,
+        #[arg(long = "owner-email", visible_alias = "email", alias = "owner_email")]
+        owner_email: String,
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
@@ -2221,6 +2221,32 @@ fn truncate_with_ellipsis(s: &str, max_len: usize) -> String {
     }
 }
 
+fn build_account_recover_args(
+    account_name: &str,
+    owner_email: &str,
+    code: Option<&str>,
+) -> Result<Value> {
+    let mut args = json!({"account_name": account_name, "owner_email": owner_email});
+    if let Some(code) = code {
+        let c = code.trim();
+        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
+            return Err(anyhow!(
+                "Invalid recovery code format. Expected a 6-digit numeric code."
+            ));
+        }
+        args["code"] = json!(c);
+    }
+    Ok(args)
+}
+
+fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Value {
+    let mut args = json!({"owner_email": owner_email});
+    if let Some(code) = code {
+        args["code"] = json!(code);
+    }
+    args
+}
+
 /// Print tool result to stdout, respecting --human flag.
 fn print_result(tool_name: &str, text: &str, human: bool) {
     if human {
@@ -2672,40 +2698,28 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             .await?;
         }
         Some(Commands::AccountRecover {
-            ref name,
-            ref email,
+            ref account_name,
+            ref owner_email,
             ref code,
         }) => {
-            let mut args = json!({"name": name, "email": email});
-            if let Some(code) = code {
-                let c = code.trim();
-                if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-                    return Err(anyhow!(
-                        "Invalid recovery code format. Expected a 6-digit numeric code."
-                    ));
-                }
-                args["code"] = json!(c);
-            }
+            let args = build_account_recover_args(account_name, owner_email, code.as_deref())?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "account_recover", args).await?;
             let text = extract_tool_result_text(&response)?;
             print_result("account_recover", &text, cli.human);
         }
         Some(Commands::VerifyOwner {
-            ref email,
+            ref owner_email,
             ref code,
         }) => {
             if !prompt_yes_no(&format!(
                 "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                email
+                owner_email
             )) {
                 println!("Aborted.");
                 return Ok(());
             }
-            let mut args = json!({"email": email});
-            if let Some(code) = code {
-                args["code"] = json!(code);
-            }
+            let args = build_verify_owner_args(owner_email, code.as_deref());
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -4943,6 +4957,77 @@ mod tests {
                 "arguments": arguments
             }
         })
+    }
+
+    #[test]
+    fn verify_owner_args_use_api_field_names() {
+        let args = build_verify_owner_args("owner@example.com", Some("123456"));
+
+        assert_eq!(
+            args,
+            json!({"owner_email": "owner@example.com", "code": "123456"})
+        );
+        assert!(args.get("email").is_none());
+    }
+
+    #[test]
+    fn account_recover_args_use_api_field_names() {
+        let args =
+            build_account_recover_args("test-account", "owner@example.com", Some(" 123456 "))
+                .unwrap();
+
+        assert_eq!(
+            args,
+            json!({
+                "account_name": "test-account",
+                "owner_email": "owner@example.com",
+                "code": "123456"
+            })
+        );
+        assert!(args.get("name").is_none());
+        assert!(args.get("email").is_none());
+    }
+
+    #[test]
+    fn owner_commands_accept_legacy_and_canonical_flags() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--email",
+            "owner@example.com",
+            "--code",
+            "123456",
+        ])
+        .unwrap();
+        match cli.command.unwrap() {
+            Commands::VerifyOwner { owner_email, code } => {
+                assert_eq!(owner_email, "owner@example.com");
+                assert_eq!(code.as_deref(), Some("123456"));
+            }
+            _ => panic!("expected verify-owner command"),
+        }
+
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "account-recover",
+            "--name",
+            "test-account",
+            "--owner-email",
+            "owner@example.com",
+        ])
+        .unwrap();
+        match cli.command.unwrap() {
+            Commands::AccountRecover {
+                account_name,
+                owner_email,
+                code,
+            } => {
+                assert_eq!(account_name, "test-account");
+                assert_eq!(owner_email, "owner@example.com");
+                assert!(code.is_none());
+            }
+            _ => panic!("expected account-recover command"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Send `owner_email` to `verify_owner` instead of the legacy `email` field.
- Send `account_name` and `owner_email` to `account_recover` while keeping existing legacy CLI flags working.
- Add focused tests for payload construction and flag compatibility.

## Tests
- `cargo test owner`
- `cargo test account_recover_args_use_api_field_names`
- `cargo clippy -- -D warnings`
- `cargo test`

## Risks
- Low. This only changes CLI-side JSON payload field names for owner verification and recovery. Legacy flags remain accepted.

## Rollback
- Revert this PR to restore the previous CLI payload construction.