### PR TITLE
Fix non-interactive verify-owner CLI flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ If your agent's credentials are lost or corrupted, you can recover the account u
 
 ### What is owner verification?
 
-Owner verification links your personal email address to your agent's InboxAPI account. Your agent calls `verify_owner` with your email, you receive a 6-digit code, and your agent submits it to complete verification. Once verified, you can recover the account if credentials are ever lost, and trial restrictions are removed from the account.
+Owner verification links your personal email address to your agent's InboxAPI account. Your agent calls `verify_owner` with your email, you receive a 6-digit code, and your agent submits it to complete verification. Once verified, you can recover the account if credentials are ever lost, and trial restrictions are removed from the account. The CLI subcommand `verify-owner` prompts for confirmation by default; use `--yes` for non-interactive runs.
 
 ### What domains are blocked from sending?
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -89,6 +89,7 @@ You can link a human owner's email address to your account using `verify_owner`.
 
 1. **Request a code** — call `verify_owner` with the owner's email address. A 6-digit verification code is sent to that address.
 2. **Submit the code** — call `verify_owner` again with both the email and the code. Once verified, the owner email is permanently linked to your account.
+3. **Automation note** — the CLI subcommand `verify-owner` prompts for confirmation by default; use `--yes` in scripted or agent-driven flows.
 
 Owner verification removes trial restrictions and enables account recovery.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1878,15 +1878,20 @@ fn build_send_email_args(
     args
 }
 
+fn normalize_six_digit_code<'a>(code: &'a str, code_kind: &str) -> Result<&'a str> {
+    let c = code.trim();
+    if c.len() != 6 || !c.chars().all(|ch| ch.is_ascii_digit()) {
+        return Err(anyhow!(
+            "Invalid {code_kind} code format. Expected a 6-digit numeric code."
+        ));
+    }
+    Ok(c)
+}
+
 fn build_account_recover_args(name: &str, email: &str, code: Option<&str>) -> Result<Value> {
     let mut args = json!({"account_name": name, "owner_email": email});
     if let Some(code) = code {
-        let c = code.trim();
-        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-            return Err(anyhow!(
-                "Invalid recovery code format. Expected a 6-digit numeric code."
-            ));
-        }
+        let c = normalize_six_digit_code(code, "recovery")?;
         args["code"] = json!(c);
     }
     Ok(args)
@@ -1895,12 +1900,7 @@ fn build_account_recover_args(name: &str, email: &str, code: Option<&str>) -> Re
 fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Result<Value> {
     let mut args = json!({"owner_email": owner_email});
     if let Some(code) = code {
-        let c = code.trim();
-        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
-            return Err(anyhow!(
-                "Invalid verification code format. Expected a 6-digit numeric code."
-            ));
-        }
+        let c = normalize_six_digit_code(code, "verification")?;
         args["code"] = json!(c);
     }
     Ok(args)

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,6 +307,9 @@ enum Commands {
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
+        /// Skip the interactive confirmation prompt
+        #[arg(long)]
+        yes: bool,
     },
     /// Enable email encryption
     EnableEncryption,
@@ -1889,12 +1892,18 @@ fn build_account_recover_args(name: &str, email: &str, code: Option<&str>) -> Re
     Ok(args)
 }
 
-fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Value {
+fn build_verify_owner_args(owner_email: &str, code: Option<&str>) -> Result<Value> {
     let mut args = json!({"owner_email": owner_email});
     if let Some(code) = code {
-        args["code"] = json!(code);
+        let c = code.trim();
+        if !(c.len() == 6 && c.chars().all(|ch| ch.is_ascii_digit())) {
+            return Err(anyhow!(
+                "Invalid verification code format. Expected a 6-digit numeric code."
+            ));
+        }
+        args["code"] = json!(c);
     }
-    args
+    Ok(args)
 }
 
 fn resolve_body_input(
@@ -2707,15 +2716,18 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
         Some(Commands::VerifyOwner {
             ref owner_email,
             ref code,
+            yes,
         }) => {
-            if !prompt_yes_no(&format!(
-                "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                owner_email
-            )) {
+            if !yes
+                && !prompt_yes_no(&format!(
+                    "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
+                    owner_email
+                ))
+            {
                 println!("Aborted.");
                 return Ok(());
             }
-            let args = build_verify_owner_args(owner_email, code.as_deref());
+            let args = build_verify_owner_args(owner_email, code.as_deref())?;
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "verify_owner", args).await?;
             let text = extract_tool_result_text(&response)?;
@@ -7752,7 +7764,7 @@ mod tests {
 
     #[test]
     fn test_verify_owner_args_use_owner_email() {
-        let args = build_verify_owner_args("owner@example.com", None);
+        let args = build_verify_owner_args("owner@example.com", None).unwrap();
 
         assert_eq!(args["owner_email"], "owner@example.com");
         assert!(args.get("email").is_none());
@@ -7761,21 +7773,30 @@ mod tests {
 
     #[test]
     fn test_verify_owner_args_include_code() {
-        let args = build_verify_owner_args("owner@example.com", Some("654321"));
+        let args = build_verify_owner_args("owner@example.com", Some("654321")).unwrap();
 
         assert_eq!(args["owner_email"], "owner@example.com");
         assert_eq!(args["code"], "654321");
     }
 
     #[test]
-    fn test_verify_owner_accepts_owner_email_flag_and_email_alias() {
+    fn test_verify_owner_args_trim_and_validate_code() {
+        let args = build_verify_owner_args("owner@example.com", Some(" 654321 ")).unwrap();
+
+        assert_eq!(args["code"], "654321");
+        assert!(build_verify_owner_args("owner@example.com", Some("abc123")).is_err());
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_owner_email_flag_email_alias_and_yes_flag() {
         let cli =
             Cli::try_parse_from(["inboxapi", "verify-owner", "--owner-email", "a@b.com"]).unwrap();
         assert!(matches!(
             cli.command,
             Some(Commands::VerifyOwner {
                 owner_email,
-                code: None
+                code: None,
+                yes: false
             }) if owner_email == "a@b.com"
         ));
 
@@ -7784,7 +7805,8 @@ mod tests {
             cli.command,
             Some(Commands::VerifyOwner {
                 owner_email,
-                code: None
+                code: None,
+                yes: false
             }) if owner_email == "a@b.com"
         ));
 
@@ -7794,7 +7816,25 @@ mod tests {
             cli.command,
             Some(Commands::VerifyOwner {
                 owner_email,
-                code: None
+                code: None,
+                yes: false
+            }) if owner_email == "a@b.com"
+        ));
+
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--owner-email",
+            "a@b.com",
+            "--yes",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::VerifyOwner {
+                owner_email,
+                code: None,
+                yes: true
             }) if owner_email == "a@b.com"
         ));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7744,11 +7744,26 @@ mod tests {
     fn test_account_recover_args_use_api_field_names() {
         let args = build_account_recover_args("agent-name", "owner@example.com", None).unwrap();
 
-        assert_eq!(args["account_name"], "agent-name");
-        assert_eq!(args["owner_email"], "owner@example.com");
-        assert!(args.get("name").is_none());
-        assert!(args.get("email").is_none());
-        assert!(args.get("code").is_none());
+        assert_eq!(
+            args["account_name"], "agent-name",
+            "account_recover args should use account_name"
+        );
+        assert_eq!(
+            args["owner_email"], "owner@example.com",
+            "account_recover args should use owner_email"
+        );
+        assert!(
+            args.get("name").is_none(),
+            "account_recover args should not use legacy name"
+        );
+        assert!(
+            args.get("email").is_none(),
+            "account_recover args should not use legacy email"
+        );
+        assert!(
+            args.get("code").is_none(),
+            "account_recover args should omit code when absent"
+        );
     }
 
     #[test]
@@ -7756,9 +7771,13 @@ mod tests {
         let args = build_account_recover_args("agent-name", "owner@example.com", Some(" 123456 "))
             .unwrap();
 
-        assert_eq!(args["code"], "123456");
+        assert_eq!(
+            args["code"], "123456",
+            "account_recover args should trim recovery code"
+        );
         assert!(
-            build_account_recover_args("agent-name", "owner@example.com", Some("abc123")).is_err()
+            build_account_recover_args("agent-name", "owner@example.com", Some("abc123")).is_err(),
+            "account_recover args should reject non-numeric recovery code"
         );
     }
 
@@ -7766,60 +7785,90 @@ mod tests {
     fn test_verify_owner_args_use_owner_email() {
         let args = build_verify_owner_args("owner@example.com", None).unwrap();
 
-        assert_eq!(args["owner_email"], "owner@example.com");
-        assert!(args.get("email").is_none());
-        assert!(args.get("code").is_none());
+        assert_eq!(
+            args["owner_email"], "owner@example.com",
+            "verify_owner args should use owner_email"
+        );
+        assert!(
+            args.get("email").is_none(),
+            "verify_owner args should not use legacy email"
+        );
+        assert!(
+            args.get("code").is_none(),
+            "verify_owner args should omit code when absent"
+        );
     }
 
     #[test]
     fn test_verify_owner_args_include_code() {
         let args = build_verify_owner_args("owner@example.com", Some("654321")).unwrap();
 
-        assert_eq!(args["owner_email"], "owner@example.com");
-        assert_eq!(args["code"], "654321");
+        assert_eq!(
+            args["owner_email"], "owner@example.com",
+            "verify_owner args should use owner_email"
+        );
+        assert_eq!(
+            args["code"], "654321",
+            "verify_owner args should include verification code"
+        );
     }
 
     #[test]
     fn test_verify_owner_args_trim_and_validate_code() {
         let args = build_verify_owner_args("owner@example.com", Some(" 654321 ")).unwrap();
 
-        assert_eq!(args["code"], "654321");
-        assert!(build_verify_owner_args("owner@example.com", Some("abc123")).is_err());
+        assert_eq!(
+            args["code"], "654321",
+            "verify_owner args should trim verification code"
+        );
+        assert!(
+            build_verify_owner_args("owner@example.com", Some("abc123")).is_err(),
+            "verify_owner args should reject non-numeric verification code"
+        );
     }
 
     #[test]
     fn test_verify_owner_accepts_owner_email_flag_email_alias_and_yes_flag() {
         let cli =
             Cli::try_parse_from(["inboxapi", "verify-owner", "--owner-email", "a@b.com"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Some(Commands::VerifyOwner {
-                owner_email,
-                code: None,
-                yes: false
-            }) if owner_email == "a@b.com"
-        ));
+        assert!(
+            matches!(
+                cli.command,
+                Some(Commands::VerifyOwner {
+                    owner_email,
+                    code: None,
+                    yes: false
+                }) if owner_email == "a@b.com"
+            ),
+            "verify-owner should accept --owner-email without --yes"
+        );
 
         let cli = Cli::try_parse_from(["inboxapi", "verify-owner", "--email", "a@b.com"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Some(Commands::VerifyOwner {
-                owner_email,
-                code: None,
-                yes: false
-            }) if owner_email == "a@b.com"
-        ));
+        assert!(
+            matches!(
+                cli.command,
+                Some(Commands::VerifyOwner {
+                    owner_email,
+                    code: None,
+                    yes: false
+                }) if owner_email == "a@b.com"
+            ),
+            "verify-owner should accept --email alias without --yes"
+        );
 
         let cli =
             Cli::try_parse_from(["inboxapi", "verify-owner", "--owner_email", "a@b.com"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Some(Commands::VerifyOwner {
-                owner_email,
-                code: None,
-                yes: false
-            }) if owner_email == "a@b.com"
-        ));
+        assert!(
+            matches!(
+                cli.command,
+                Some(Commands::VerifyOwner {
+                    owner_email,
+                    code: None,
+                    yes: false
+                }) if owner_email == "a@b.com"
+            ),
+            "verify-owner should accept --owner_email alias without --yes"
+        );
 
         let cli = Cli::try_parse_from([
             "inboxapi",
@@ -7829,14 +7878,17 @@ mod tests {
             "--yes",
         ])
         .unwrap();
-        assert!(matches!(
-            cli.command,
-            Some(Commands::VerifyOwner {
-                owner_email,
-                code: None,
-                yes: true
-            }) if owner_email == "a@b.com"
-        ));
+        assert!(
+            matches!(
+                cli.command,
+                Some(Commands::VerifyOwner {
+                    owner_email,
+                    code: None,
+                    yes: true
+                }) if owner_email == "a@b.com"
+            ),
+            "verify-owner should accept --yes for non-interactive runs"
+        );
     }
 
     // --- build_attachment_from_file tests ---


### PR DESCRIPTION
## Summary
- add a  flag to  so scripted and agent-driven runs can skip the TTY confirmation prompt
- validate and trim the 6-digit verification code locally before calling the API
- document the non-interactive flow in the CLI docs

## Verification
- cargo fmt
- cargo clippy -- -D warnings
- cargo test
- cargo build
- cargo run -- verify-owner --owner-email owner@example.com --yes
- cargo run -- verify-owner --owner-email owner@example.com --code abc123 --yes
