### PR TITLE
Add non-interactive verify-owner confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ If your agent's credentials are lost or corrupted, you can recover the account u
 
 Owner verification links your personal email address to your agent's InboxAPI account. Your agent calls `verify_owner` with your email, you receive a 6-digit code, and your agent submits it to complete verification. Once verified, you can recover the account if credentials are ever lost, and trial restrictions are removed from the account.
 
+The CLI asks for confirmation before linking an owner email. Use `inboxapi verify-owner --email you@example.com --yes` for non-interactive runs after the action has been explicitly approved.
+
 ### What domains are blocked from sending?
 
 InboxAPI maintains a denylist that blocks sending to government (.gov), military (.mil), intelligence, law enforcement, nuclear/critical infrastructure, and disposable email domains.

--- a/docs/help.md
+++ b/docs/help.md
@@ -92,6 +92,9 @@ You can link a human owner's email address to your account using `verify_owner`.
 
 Owner verification removes trial restrictions and enables account recovery.
 
+The CLI prompts before linking an owner email. For non-interactive runs where
+the caller has already confirmed this action, pass `--yes`.
+
 ---
 
 ## Account Recovery

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,6 +307,9 @@ enum Commands {
         /// Verification code (if already received)
         #[arg(long)]
         code: Option<String>,
+        /// Confirm linking this owner email without prompting
+        #[arg(long)]
+        yes: bool,
     },
     /// Enable email encryption
     EnableEncryption,
@@ -2299,6 +2302,7 @@ Examples:
   inboxapi get-thread --message-id \"<msg-id>\"
   inboxapi get-addressbook
   inboxapi search-emails --subject \"invoice\"
+  inboxapi verify-owner --email owner@example.com --yes
   inboxapi get-attachment abc123 --output ./file.pdf
   inboxapi send-reply --message-id \"<msg-id>\" --body \"Thanks!\"
   inboxapi send-reply --message-id \"<msg-id>\" --body-file ./reply.txt --html-body-file ./reply.html
@@ -2707,11 +2711,14 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
         Some(Commands::VerifyOwner {
             ref owner_email,
             ref code,
+            yes,
         }) => {
-            if !prompt_yes_no(&format!(
-                "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
-                owner_email
-            )) {
+            if !yes
+                && !prompt_yes_no(&format!(
+                    "WARNING: This will link {} to your account for recovery. Continue? [y/N] ",
+                    owner_email
+                ))
+            {
                 println!("Aborted.");
                 return Ok(());
             }
@@ -7775,7 +7782,8 @@ mod tests {
             cli.command,
             Some(Commands::VerifyOwner {
                 owner_email,
-                code: None
+                code: None,
+                yes: false
             }) if owner_email == "a@b.com"
         ));
 
@@ -7784,7 +7792,8 @@ mod tests {
             cli.command,
             Some(Commands::VerifyOwner {
                 owner_email,
-                code: None
+                code: None,
+                yes: false
             }) if owner_email == "a@b.com"
         ));
 
@@ -7794,8 +7803,32 @@ mod tests {
             cli.command,
             Some(Commands::VerifyOwner {
                 owner_email,
-                code: None
+                code: None,
+                yes: false
             }) if owner_email == "a@b.com"
+        ));
+    }
+
+    #[test]
+    fn test_verify_owner_accepts_yes_flag() {
+        let cli = Cli::try_parse_from([
+            "inboxapi",
+            "verify-owner",
+            "--email",
+            "a@b.com",
+            "--code",
+            "123456",
+            "--yes",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            cli.command,
+            Some(Commands::VerifyOwner {
+                owner_email,
+                code: Some(code),
+                yes: true
+            }) if owner_email == "a@b.com" && code == "123456"
         ));
     }
 


### PR DESCRIPTION
## Summary
- Add a `--yes` flag to `inboxapi verify-owner` so confirmed non-interactive runs can skip the stdin prompt.
- Keep the existing confirmation prompt as the default behaviour.
- Document the flag in README/help text and cover parsing with a unit test.

## Verification
- `cargo fmt --check`
- `cargo test verify_owner -- --nocapture`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo run --quiet -- verify-owner --help`

## Risks and rollback
- Risk is low and limited to the `verify-owner` CLI path; default interactive behaviour is unchanged.
- Rollback by reverting this PR if needed.