### PR TITLE
🐛 fix: surface reply-all recipients

### DIFF
--- a/skills/claude/email-reply/SKILL.md
+++ b/skills/claude/email-reply/SKILL.md
@@ -23,13 +23,21 @@ Help the user reply to an email with full thread context.
    ```
    --- Thread: <subject> ---
 
-   [1] From: alice@example.com (Jan 15, 2:30 PM)
+   [1] From: alice@example.com
+       To: agent@inboxapi.ai, bob@example.com
+       Cc: team@example.com
+       Date: Jan 15, 2:30 PM
    > Original message text...
 
-   [2] From: you@inboxapi.ai (Jan 15, 3:00 PM)
+   [2] From: you@inboxapi.ai
+       To: alice@example.com
+       Date: Jan 15, 3:00 PM
    > Your previous reply...
 
-   [3] From: alice@example.com (Jan 15, 4:15 PM)
+   [3] From: alice@example.com
+       To: agent@inboxapi.ai, bob@example.com
+       Cc: team@example.com
+       Date: Jan 15, 4:15 PM
    > Latest message you're replying to...
    ```
 
@@ -38,10 +46,17 @@ Help the user reply to an email with full thread context.
 5. **Preview**: Show the reply before sending:
    ```
    Replying to: alice@example.com
+   To: alice@example.com
+   Cc: bob@example.com, team@example.com
    Subject: Re: <subject>
    ---
    <reply body>
    ```
+   Derive `To`/`Cc` from the thread exactly as InboxAPI does:
+   - primary `To` is `Reply-To` if present, otherwise the original sender
+   - preserve all original thread participants from `To`/`Cc` in `Cc`
+   - exclude only the current mailbox itself
+   - use `--cc` only for new recipients beyond the original thread
 
 6. **Confirm**: Ask "Send this reply? (yes/no)"
 
@@ -71,7 +86,7 @@ Help the user reply to an email with full thread context.
 ## Rules
 
 - ALWAYS show the thread context before composing
-- ALWAYS preview and confirm before sending
+- ALWAYS preview the exact resolved `To`/`Cc` set and confirm before sending
 - NEVER send without explicit user confirmation
 - Do not manually include original thread recipients in `--cc`; `send-reply` auto-preserves them on multi-recipient threads
 - Use `--reply-all` when the user explicitly requests to reply to all recipients

--- a/skills/claude/email-reply/SKILL.md
+++ b/skills/claude/email-reply/SKILL.md
@@ -19,31 +19,38 @@ Help the user reply to an email with full thread context.
 
 2. **Load thread context**: Run: `npx -y @inboxapi/cli get-thread --message-id "<message-id>"` with the email's message ID to show the full conversation
 
-3. **Display thread**: Show the conversation history in chronological order:
+3. **Load mailbox identity**: Run `npx -y @inboxapi/cli whoami` so you know the current mailbox email and can exclude only that mailbox from preserved thread recipients
+
+4. **Display thread**: Show the conversation history in chronological order:
    ```
    --- Thread: <subject> ---
 
    [1] From: alice@example.com
        To: agent@inboxapi.ai, bob@example.com
        Cc: team@example.com
+       Reply-To: replies@example.com
        Date: Jan 15, 2:30 PM
+       Subject: <subject>
    > Original message text...
 
    [2] From: you@inboxapi.ai
        To: alice@example.com
        Date: Jan 15, 3:00 PM
+       Subject: Re: <subject>
    > Your previous reply...
 
    [3] From: alice@example.com
        To: agent@inboxapi.ai, bob@example.com
        Cc: team@example.com
+       Reply-To: replies@example.com
        Date: Jan 15, 4:15 PM
+       Subject: Re: <subject>
    > Latest message you're replying to...
    ```
 
-4. **Compose reply**: Ask the user what they want to say in their reply
+5. **Compose reply**: Ask the user what they want to say in their reply
 
-5. **Preview**: Show the reply before sending:
+6. **Preview**: Show the reply before sending:
    ```
    Replying to: alice@example.com
    To: alice@example.com
@@ -56,11 +63,12 @@ Help the user reply to an email with full thread context.
    - primary `To` is `Reply-To` if present, otherwise the original sender
    - preserve all original thread participants from `To`/`Cc` in `Cc`
    - exclude only the current mailbox itself
+   - use the mailbox email from `whoami` to determine which participant is “self”
    - use `--cc` only for new recipients beyond the original thread
 
-6. **Confirm**: Ask "Send this reply? (yes/no)"
+7. **Confirm**: Ask "Send this reply? (yes/no)"
 
-7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
+8. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
    If the reply body or HTML is complex, prefer `--body-file "<path>"` and `--html-body-file "<path>"` over generating helper scripts just to pass content on the command line. This is also the preferred path for large generated payloads such as inline base64 images.
 
    **Recipient behavior**: By default, `send-reply` auto-preserves original thread recipients for multi-recipient conversations. Use `--reply-all` to force reply-all even if the server would not auto-select it, and use `--cc` only to add new CC recipients beyond the original thread:

--- a/skills/claude/email-reply/SKILL.md
+++ b/skills/claude/email-reply/SKILL.md
@@ -59,12 +59,13 @@ Help the user reply to an email with full thread context.
    ---
    <reply body>
    ```
-   Derive `To`/`Cc` from the thread exactly as InboxAPI does:
+   Preview the likely `To`/`Cc` set using the thread context:
    - primary `To` is `Reply-To` if present, otherwise the original sender
    - preserve all original thread participants from `To`/`Cc` in `Cc`
    - exclude only the current mailbox itself
    - use the mailbox email from `whoami` to determine which participant is “self”
    - use `--cc` only for new recipients beyond the original thread
+   Treat this as a preview heuristic. The authoritative final recipient set is whatever `send-reply` returns after the send.
 
 7. **Confirm**: Ask "Send this reply? (yes/no)"
 

--- a/skills/codex/email-reply/SKILL.md
+++ b/skills/codex/email-reply/SKILL.md
@@ -20,13 +20,21 @@ Help the user reply to an email with full thread context.
    ```
    --- Thread: <subject> ---
 
-   [1] From: alice@example.com (Jan 15, 2:30 PM)
+   [1] From: alice@example.com
+       To: agent@inboxapi.ai, bob@example.com
+       Cc: team@example.com
+       Date: Jan 15, 2:30 PM
    > Original message text...
 
-   [2] From: you@inboxapi.ai (Jan 15, 3:00 PM)
+   [2] From: you@inboxapi.ai
+       To: alice@example.com
+       Date: Jan 15, 3:00 PM
    > Your previous reply...
 
-   [3] From: alice@example.com (Jan 15, 4:15 PM)
+   [3] From: alice@example.com
+       To: agent@inboxapi.ai, bob@example.com
+       Cc: team@example.com
+       Date: Jan 15, 4:15 PM
    > Latest message you're replying to...
    ```
 
@@ -35,10 +43,17 @@ Help the user reply to an email with full thread context.
 5. **Preview**: Show the reply before sending:
    ```
    Replying to: alice@example.com
+   To: alice@example.com
+   Cc: bob@example.com, team@example.com
    Subject: Re: <subject>
    ---
    <reply body>
    ```
+   Derive `To`/`Cc` from the thread exactly as InboxAPI does:
+   - primary `To` is `Reply-To` if present, otherwise the original sender
+   - preserve all original thread participants from `To`/`Cc` in `Cc`
+   - exclude only the current mailbox itself
+   - use `--cc` only for new recipients beyond the original thread
 
 6. **Confirm**: Ask "Send this reply? (yes/no)"
 
@@ -68,7 +83,7 @@ Help the user reply to an email with full thread context.
 ## Rules
 
 - ALWAYS show the thread context before composing
-- ALWAYS preview and confirm before sending
+- ALWAYS preview the exact resolved `To`/`Cc` set and confirm before sending
 - NEVER send without explicit user confirmation
 - Do not manually include original thread recipients in `--cc`; `send-reply` auto-preserves them on multi-recipient threads
 - Use `--reply-all` when the user explicitly requests to reply to all recipients

--- a/skills/codex/email-reply/SKILL.md
+++ b/skills/codex/email-reply/SKILL.md
@@ -56,12 +56,13 @@ Help the user reply to an email with full thread context.
    ---
    <reply body>
    ```
-   Derive `To`/`Cc` from the thread exactly as InboxAPI does:
+   Preview the likely `To`/`Cc` set using the thread context:
    - primary `To` is `Reply-To` if present, otherwise the original sender
    - preserve all original thread participants from `To`/`Cc` in `Cc`
    - exclude only the current mailbox itself
    - use the mailbox email from `whoami` to determine which participant is “self”
    - use `--cc` only for new recipients beyond the original thread
+   Treat this as a preview heuristic. The authoritative final recipient set is whatever `send-reply` returns after the send.
 
 7. **Confirm**: Ask "Send this reply? (yes/no)"
 

--- a/skills/codex/email-reply/SKILL.md
+++ b/skills/codex/email-reply/SKILL.md
@@ -16,31 +16,38 @@ Help the user reply to an email with full thread context.
 
 2. **Load thread context**: Run: `npx -y @inboxapi/cli get-thread --message-id "<message-id>"` with the email's message ID to show the full conversation
 
-3. **Display thread**: Show the conversation history in chronological order:
+3. **Load mailbox identity**: Run `npx -y @inboxapi/cli whoami` so you know the current mailbox email and can exclude only that mailbox from preserved thread recipients
+
+4. **Display thread**: Show the conversation history in chronological order:
    ```
    --- Thread: <subject> ---
 
    [1] From: alice@example.com
        To: agent@inboxapi.ai, bob@example.com
        Cc: team@example.com
+       Reply-To: replies@example.com
        Date: Jan 15, 2:30 PM
+       Subject: <subject>
    > Original message text...
 
    [2] From: you@inboxapi.ai
        To: alice@example.com
        Date: Jan 15, 3:00 PM
+       Subject: Re: <subject>
    > Your previous reply...
 
    [3] From: alice@example.com
        To: agent@inboxapi.ai, bob@example.com
        Cc: team@example.com
+       Reply-To: replies@example.com
        Date: Jan 15, 4:15 PM
+       Subject: Re: <subject>
    > Latest message you're replying to...
    ```
 
-4. **Compose reply**: Ask the user what they want to say in their reply
+5. **Compose reply**: Ask the user what they want to say in their reply
 
-5. **Preview**: Show the reply before sending:
+6. **Preview**: Show the reply before sending:
    ```
    Replying to: alice@example.com
    To: alice@example.com
@@ -53,11 +60,12 @@ Help the user reply to an email with full thread context.
    - primary `To` is `Reply-To` if present, otherwise the original sender
    - preserve all original thread participants from `To`/`Cc` in `Cc`
    - exclude only the current mailbox itself
+   - use the mailbox email from `whoami` to determine which participant is “self”
    - use `--cc` only for new recipients beyond the original thread
 
-6. **Confirm**: Ask "Send this reply? (yes/no)"
+7. **Confirm**: Ask "Send this reply? (yes/no)"
 
-7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
+8. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
    If the reply body or HTML is complex, prefer `--body-file "<path>"` and `--html-body-file "<path>"` over generating helper scripts just to pass content on the command line. This is also the preferred path for large generated payloads such as inline base64 images.
 
    **Recipient behavior**: By default, `send-reply` auto-preserves original thread recipients for multi-recipient conversations. Use `--reply-all` to force reply-all even if the server would not auto-select it, and use `--cc` only to add new CC recipients beyond the original thread:

--- a/skills/gemini/email-reply/SKILL.md
+++ b/skills/gemini/email-reply/SKILL.md
@@ -20,13 +20,21 @@ Help the user reply to an email with full thread context.
    ```
    --- Thread: <subject> ---
 
-   [1] From: alice@example.com (Jan 15, 2:30 PM)
+   [1] From: alice@example.com
+       To: agent@inboxapi.ai, bob@example.com
+       Cc: team@example.com
+       Date: Jan 15, 2:30 PM
    > Original message text...
 
-   [2] From: you@inboxapi.ai (Jan 15, 3:00 PM)
+   [2] From: you@inboxapi.ai
+       To: alice@example.com
+       Date: Jan 15, 3:00 PM
    > Your previous reply...
 
-   [3] From: alice@example.com (Jan 15, 4:15 PM)
+   [3] From: alice@example.com
+       To: agent@inboxapi.ai, bob@example.com
+       Cc: team@example.com
+       Date: Jan 15, 4:15 PM
    > Latest message you're replying to...
    ```
 
@@ -35,10 +43,17 @@ Help the user reply to an email with full thread context.
 5. **Preview**: Show the reply before sending:
    ```
    Replying to: alice@example.com
+   To: alice@example.com
+   Cc: bob@example.com, team@example.com
    Subject: Re: <subject>
    ---
    <reply body>
    ```
+   Derive `To`/`Cc` from the thread exactly as InboxAPI does:
+   - primary `To` is `Reply-To` if present, otherwise the original sender
+   - preserve all original thread participants from `To`/`Cc` in `Cc`
+   - exclude only the current mailbox itself
+   - use `--cc` only for new recipients beyond the original thread
 
 6. **Confirm**: Ask "Send this reply? (yes/no)"
 
@@ -68,7 +83,7 @@ Help the user reply to an email with full thread context.
 ## Rules
 
 - ALWAYS show the thread context before composing
-- ALWAYS preview and confirm before sending
+- ALWAYS preview the exact resolved `To`/`Cc` set and confirm before sending
 - NEVER send without explicit user confirmation
 - Do not manually include original thread recipients in `--cc`; `send-reply` auto-preserves them on multi-recipient threads
 - Use `--reply-all` when the user explicitly requests to reply to all recipients

--- a/skills/gemini/email-reply/SKILL.md
+++ b/skills/gemini/email-reply/SKILL.md
@@ -56,12 +56,13 @@ Help the user reply to an email with full thread context.
    ---
    <reply body>
    ```
-   Derive `To`/`Cc` from the thread exactly as InboxAPI does:
+   Preview the likely `To`/`Cc` set using the thread context:
    - primary `To` is `Reply-To` if present, otherwise the original sender
    - preserve all original thread participants from `To`/`Cc` in `Cc`
    - exclude only the current mailbox itself
    - use the mailbox email from `whoami` to determine which participant is “self”
    - use `--cc` only for new recipients beyond the original thread
+   Treat this as a preview heuristic. The authoritative final recipient set is whatever `send-reply` returns after the send.
 
 7. **Confirm**: Ask "Send this reply? (yes/no)"
 

--- a/skills/gemini/email-reply/SKILL.md
+++ b/skills/gemini/email-reply/SKILL.md
@@ -16,31 +16,38 @@ Help the user reply to an email with full thread context.
 
 2. **Load thread context**: Run: `npx -y @inboxapi/cli get-thread --message-id "<message-id>"` with the email's message ID to show the full conversation
 
-3. **Display thread**: Show the conversation history in chronological order:
+3. **Load mailbox identity**: Run `npx -y @inboxapi/cli whoami` so you know the current mailbox email and can exclude only that mailbox from preserved thread recipients
+
+4. **Display thread**: Show the conversation history in chronological order:
    ```
    --- Thread: <subject> ---
 
    [1] From: alice@example.com
        To: agent@inboxapi.ai, bob@example.com
        Cc: team@example.com
+       Reply-To: replies@example.com
        Date: Jan 15, 2:30 PM
+       Subject: <subject>
    > Original message text...
 
    [2] From: you@inboxapi.ai
        To: alice@example.com
        Date: Jan 15, 3:00 PM
+       Subject: Re: <subject>
    > Your previous reply...
 
    [3] From: alice@example.com
        To: agent@inboxapi.ai, bob@example.com
        Cc: team@example.com
+       Reply-To: replies@example.com
        Date: Jan 15, 4:15 PM
+       Subject: Re: <subject>
    > Latest message you're replying to...
    ```
 
-4. **Compose reply**: Ask the user what they want to say in their reply
+5. **Compose reply**: Ask the user what they want to say in their reply
 
-5. **Preview**: Show the reply before sending:
+6. **Preview**: Show the reply before sending:
    ```
    Replying to: alice@example.com
    To: alice@example.com
@@ -53,11 +60,12 @@ Help the user reply to an email with full thread context.
    - primary `To` is `Reply-To` if present, otherwise the original sender
    - preserve all original thread participants from `To`/`Cc` in `Cc`
    - exclude only the current mailbox itself
+   - use the mailbox email from `whoami` to determine which participant is “self”
    - use `--cc` only for new recipients beyond the original thread
 
-6. **Confirm**: Ask "Send this reply? (yes/no)"
+7. **Confirm**: Ask "Send this reply? (yes/no)"
 
-7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
+8. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
    If the reply body or HTML is complex, prefer `--body-file "<path>"` and `--html-body-file "<path>"` over generating helper scripts just to pass content on the command line. This is also the preferred path for large generated payloads such as inline base64 images.
 
    **Recipient behavior**: By default, `send-reply` auto-preserves original thread recipients for multi-recipient conversations. Use `--reply-all` to force reply-all even if the server would not auto-select it, and use `--cc` only to add new CC recipients beyond the original thread:

--- a/skills/hooks/email-send-guard.js
+++ b/skills/hooks/email-send-guard.js
@@ -51,11 +51,12 @@ function main() {
       if (replyAll) extras.push("reply-all forced");
       if (explicitCc) extras.push(`extra cc: ${explicitCc}`);
       toDisplay = `resolved from thread ${threadRef}${extras.length ? ` (${extras.join("; ")})` : ""}`;
+      subject = "(resolved from thread)";
     } else {
       toDisplay = (toMatch && (toMatch[1] || toMatch[2] || toMatch[3] || "").trim()) || "(unknown)";
+      const subjectMatch = cmd.match(/--subject(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(.+?)(?=\s+--|$))/);
+      subject = (subjectMatch && (subjectMatch[1] || subjectMatch[2] || subjectMatch[3] || "").trim()) || "(no subject)";
     }
-    const subjectMatch = cmd.match(/--subject(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(.+?)(?=\s+--|$))/);
-    subject = (subjectMatch && (subjectMatch[1] || subjectMatch[2] || subjectMatch[3] || "").trim()) || "(no subject)";
     const bodyMatch = cmd.match(/--body(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(.+?)(?=\s+--|$))/);
     body = (bodyMatch && (bodyMatch[1] || bodyMatch[2] || bodyMatch[3] || "").trim()) || "";
     action = isForward ? "FORWARD" : isReply ? "REPLY" : "SEND";
@@ -77,12 +78,13 @@ function main() {
         extras.push(`extra cc: ${ccList.join(", ")}`);
       }
       toDisplay = `resolved from thread ${toolInput.in_reply_to || "(unknown thread)"}${extras.length ? ` (${extras.join("; ")})` : ""}`;
+      subject = "(resolved from thread)";
     } else {
       const rawTo = toolInput.to || toolInput.recipient || "(unknown)";
       const toList = Array.isArray(rawTo) ? rawTo : [rawTo];
       toDisplay = toList.join(", ");
+      subject = toolInput.subject || "(no subject)";
     }
-    subject = toolInput.subject || "(no subject)";
     body = toolInput.body || toolInput.message || "";
     action = toolName.includes("forward")
       ? "FORWARD"

--- a/skills/hooks/email-send-guard.js
+++ b/skills/hooks/email-send-guard.js
@@ -5,6 +5,12 @@
 
 const fs = require("fs");
 
+function hasStandaloneFlag(cmd, flag) {
+  const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`(?:^|\\s)${escaped}(?=\\s|$)`);
+  return pattern.test(cmd);
+}
+
 function main() {
   const input = fs.readFileSync(0, "utf8");
   let data;
@@ -37,7 +43,7 @@ function main() {
     const toMatch = cmd.match(/--to(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(.+?)(?=\s+--|$))/);
     const messageIdMatch = cmd.match(/--message-id(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(.+?)(?=\s+--|$))/);
     const ccMatch = cmd.match(/--cc(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(.+?)(?=\s+--|$))/);
-    const replyAll = cmd.includes("--reply-all");
+    const replyAll = hasStandaloneFlag(cmd, "--reply-all");
     const explicitCc = (ccMatch && (ccMatch[1] || ccMatch[2] || ccMatch[3] || "").trim()) || "";
     if (isReply) {
       const threadRef = (messageIdMatch && (messageIdMatch[1] || messageIdMatch[2] || messageIdMatch[3] || "").trim()) || "(unknown thread)";

--- a/skills/hooks/email-send-guard.js
+++ b/skills/hooks/email-send-guard.js
@@ -35,7 +35,19 @@ function main() {
     // Best-effort extraction from CLI flags
     // Captures: "quoted", 'quoted', or unquoted value until next --flag or end of string
     const toMatch = cmd.match(/--to(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(.+?)(?=\s+--|$))/);
-    toDisplay = (toMatch && (toMatch[1] || toMatch[2] || toMatch[3] || "").trim()) || "(unknown)";
+    const messageIdMatch = cmd.match(/--message-id(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(.+?)(?=\s+--|$))/);
+    const ccMatch = cmd.match(/--cc(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(.+?)(?=\s+--|$))/);
+    const replyAll = cmd.includes("--reply-all");
+    const explicitCc = (ccMatch && (ccMatch[1] || ccMatch[2] || ccMatch[3] || "").trim()) || "";
+    if (isReply) {
+      const threadRef = (messageIdMatch && (messageIdMatch[1] || messageIdMatch[2] || messageIdMatch[3] || "").trim()) || "(unknown thread)";
+      const extras = [];
+      if (replyAll) extras.push("reply-all forced");
+      if (explicitCc) extras.push(`extra cc: ${explicitCc}`);
+      toDisplay = `resolved from thread ${threadRef}${extras.length ? ` (${extras.join("; ")})` : ""}`;
+    } else {
+      toDisplay = (toMatch && (toMatch[1] || toMatch[2] || toMatch[3] || "").trim()) || "(unknown)";
+    }
     const subjectMatch = cmd.match(/--subject(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(.+?)(?=\s+--|$))/);
     subject = (subjectMatch && (subjectMatch[1] || subjectMatch[2] || subjectMatch[3] || "").trim()) || "(no subject)";
     const bodyMatch = cmd.match(/--body(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(.+?)(?=\s+--|$))/);
@@ -51,9 +63,19 @@ function main() {
       process.exit(0);
     }
 
-    const rawTo = toolInput.to || toolInput.recipient || "(unknown)";
-    const toList = Array.isArray(rawTo) ? rawTo : [rawTo];
-    toDisplay = toList.join(", ");
+    if (toolName.includes("reply")) {
+      const extras = [];
+      if (toolInput.reply_all === true) extras.push("reply-all forced");
+      if (toolInput.cc) {
+        const ccList = Array.isArray(toolInput.cc) ? toolInput.cc : [toolInput.cc];
+        extras.push(`extra cc: ${ccList.join(", ")}`);
+      }
+      toDisplay = `resolved from thread ${toolInput.in_reply_to || "(unknown thread)"}${extras.length ? ` (${extras.join("; ")})` : ""}`;
+    } else {
+      const rawTo = toolInput.to || toolInput.recipient || "(unknown)";
+      const toList = Array.isArray(rawTo) ? rawTo : [rawTo];
+      toDisplay = toList.join(", ");
+    }
     subject = toolInput.subject || "(no subject)";
     body = toolInput.body || toolInput.message || "";
     action = toolName.includes("forward")

--- a/skills/opencode/email-reply.md
+++ b/skills/opencode/email-reply.md
@@ -19,13 +19,21 @@ Help the user reply to an email with full thread context.
    ```
    --- Thread: <subject> ---
 
-   [1] From: alice@example.com (Jan 15, 2:30 PM)
+   [1] From: alice@example.com
+       To: agent@inboxapi.ai, bob@example.com
+       Cc: team@example.com
+       Date: Jan 15, 2:30 PM
    > Original message text...
 
-   [2] From: you@inboxapi.ai (Jan 15, 3:00 PM)
+   [2] From: you@inboxapi.ai
+       To: alice@example.com
+       Date: Jan 15, 3:00 PM
    > Your previous reply...
 
-   [3] From: alice@example.com (Jan 15, 4:15 PM)
+   [3] From: alice@example.com
+       To: agent@inboxapi.ai, bob@example.com
+       Cc: team@example.com
+       Date: Jan 15, 4:15 PM
    > Latest message you're replying to...
    ```
 
@@ -34,10 +42,17 @@ Help the user reply to an email with full thread context.
 5. **Preview**: Show the reply before sending:
    ```
    Replying to: alice@example.com
+   To: alice@example.com
+   Cc: bob@example.com, team@example.com
    Subject: Re: <subject>
    ---
    <reply body>
    ```
+   Derive `To`/`Cc` from the thread exactly as InboxAPI does:
+   - primary `To` is `Reply-To` if present, otherwise the original sender
+   - preserve all original thread participants from `To`/`Cc` in `Cc`
+   - exclude only the current mailbox itself
+   - use `--cc` only for new recipients beyond the original thread
 
 6. **Confirm**: Ask "Send this reply? (yes/no)"
 
@@ -67,7 +82,7 @@ Help the user reply to an email with full thread context.
 ## Rules
 
 - ALWAYS show the thread context before composing
-- ALWAYS preview and confirm before sending
+- ALWAYS preview the exact resolved `To`/`Cc` set and confirm before sending
 - NEVER send without explicit user confirmation
 - Do not manually include original thread recipients in `--cc`; `send-reply` auto-preserves them on multi-recipient threads
 - Use `--reply-all` when the user explicitly requests to reply to all recipients

--- a/skills/opencode/email-reply.md
+++ b/skills/opencode/email-reply.md
@@ -55,12 +55,13 @@ Help the user reply to an email with full thread context.
    ---
    <reply body>
    ```
-   Derive `To`/`Cc` from the thread exactly as InboxAPI does:
+   Preview the likely `To`/`Cc` set using the thread context:
    - primary `To` is `Reply-To` if present, otherwise the original sender
    - preserve all original thread participants from `To`/`Cc` in `Cc`
    - exclude only the current mailbox itself
    - use the mailbox email from `whoami` to determine which participant is “self”
    - use `--cc` only for new recipients beyond the original thread
+   Treat this as a preview heuristic. The authoritative final recipient set is whatever `send-reply` returns after the send.
 
 7. **Confirm**: Ask "Send this reply? (yes/no)"
 

--- a/skills/opencode/email-reply.md
+++ b/skills/opencode/email-reply.md
@@ -15,31 +15,38 @@ Help the user reply to an email with full thread context.
 
 2. **Load thread context**: Run: `npx -y @inboxapi/cli get-thread --message-id "<message-id>"` with the email's message ID to show the full conversation
 
-3. **Display thread**: Show the conversation history in chronological order:
+3. **Load mailbox identity**: Run `npx -y @inboxapi/cli whoami` so you know the current mailbox email and can exclude only that mailbox from preserved thread recipients
+
+4. **Display thread**: Show the conversation history in chronological order:
    ```
    --- Thread: <subject> ---
 
    [1] From: alice@example.com
        To: agent@inboxapi.ai, bob@example.com
        Cc: team@example.com
+       Reply-To: replies@example.com
        Date: Jan 15, 2:30 PM
+       Subject: <subject>
    > Original message text...
 
    [2] From: you@inboxapi.ai
        To: alice@example.com
        Date: Jan 15, 3:00 PM
+       Subject: Re: <subject>
    > Your previous reply...
 
    [3] From: alice@example.com
        To: agent@inboxapi.ai, bob@example.com
        Cc: team@example.com
+       Reply-To: replies@example.com
        Date: Jan 15, 4:15 PM
+       Subject: Re: <subject>
    > Latest message you're replying to...
    ```
 
-4. **Compose reply**: Ask the user what they want to say in their reply
+5. **Compose reply**: Ask the user what they want to say in their reply
 
-5. **Preview**: Show the reply before sending:
+6. **Preview**: Show the reply before sending:
    ```
    Replying to: alice@example.com
    To: alice@example.com
@@ -52,11 +59,12 @@ Help the user reply to an email with full thread context.
    - primary `To` is `Reply-To` if present, otherwise the original sender
    - preserve all original thread participants from `To`/`Cc` in `Cc`
    - exclude only the current mailbox itself
+   - use the mailbox email from `whoami` to determine which participant is “self”
    - use `--cc` only for new recipients beyond the original thread
 
-6. **Confirm**: Ask "Send this reply? (yes/no)"
+7. **Confirm**: Ask "Send this reply? (yes/no)"
 
-7. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
+8. **Send**: Run: `npx -y @inboxapi/cli send-reply --message-id "<id>" --body "<reply>"`
    If the reply body or HTML is complex, prefer `--body-file "<path>"` and `--html-body-file "<path>"` over generating helper scripts just to pass content on the command line. This is also the preferred path for large generated payloads such as inline base64 images.
 
    **Recipient behavior**: By default, `send-reply` auto-preserves original thread recipients for multi-recipient conversations. Use `--reply-all` to force reply-all even if the server would not auto-select it, and use `--cc` only to add new CC recipients beyond the original thread:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1989,6 +1989,22 @@ fn normalize_body_newlines(input: String) -> String {
     input.replace("\r\n", "\n").replace('\r', "\n")
 }
 
+fn json_string_or_joined_array(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .map(|s| s.to_string())
+        .or_else(|| {
+            value.as_array().map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| item.as_str().map(|s| s.to_string()))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+        })
+        .filter(|s| !s.is_empty())
+}
+
 /// Format tool result for human-readable output.
 fn format_human_output(tool_name: &str, text: &str) -> String {
     match tool_name {
@@ -2053,7 +2069,9 @@ fn format_human_output(tool_name: &str, text: &str) -> String {
                     .as_str()
                     .or_else(|| email["sender"].as_str())
                     .unwrap_or("unknown");
-                let to = email["to"].as_str().unwrap_or("");
+                let to = json_string_or_joined_array(&email["to"]).unwrap_or_default();
+                let cc = json_string_or_joined_array(&email["cc"]);
+                let reply_to = email["reply_to"].as_str().filter(|s| !s.is_empty());
                 let subject = email["subject"].as_str().unwrap_or("(no subject)");
                 let date = email["date"]
                     .as_str()
@@ -2063,10 +2081,16 @@ fn format_human_output(tool_name: &str, text: &str) -> String {
                     .as_str()
                     .or_else(|| email["text_body"].as_str())
                     .unwrap_or("");
-                format!(
-                    "From: {}\nTo: {}\nDate: {}\nSubject: {}\n\n{}",
-                    from, to, date, subject, body
-                )
+                let mut lines = vec![format!("From: {}", from), format!("To: {}", to)];
+                if let Some(cc) = cc {
+                    lines.push(format!("Cc: {}", cc));
+                }
+                if let Some(reply_to) = reply_to {
+                    lines.push(format!("Reply-To: {}", reply_to));
+                }
+                lines.push(format!("Date: {}", date));
+                lines.push(format!("Subject: {}", subject));
+                format!("{}\n\n{}", lines.join("\n"), body)
             } else {
                 text.to_string()
             }
@@ -2077,7 +2101,14 @@ fn format_human_output(tool_name: &str, text: &str) -> String {
                     .as_str()
                     .or_else(|| data["messageId"].as_str())
                     .unwrap_or("unknown");
-                format!("Reply sent. Message ID: {}", msg_id)
+                let mut lines = vec![format!("Reply sent. Message ID: {}", msg_id)];
+                if let Some(to) = json_string_or_joined_array(&data["to"]) {
+                    lines.push(format!("To: {}", to));
+                }
+                if let Some(cc) = json_string_or_joined_array(&data["cc"]) {
+                    lines.push(format!("Cc: {}", cc));
+                }
+                lines.join("\n")
             } else {
                 format!("Reply sent.\n{}", text)
             }
@@ -2125,22 +2156,33 @@ fn format_human_output(tool_name: &str, text: &str) -> String {
                             .as_str()
                             .or_else(|| msg["sender"].as_str())
                             .unwrap_or("unknown");
+                        let to = json_string_or_joined_array(&msg["to"]).unwrap_or_default();
+                        let cc = json_string_or_joined_array(&msg["cc"]);
+                        let reply_to = msg["reply_to"].as_str().filter(|s| !s.is_empty());
                         let date = msg["date"]
                             .as_str()
                             .or_else(|| msg["received_at"].as_str())
                             .unwrap_or("");
+                        let subject = msg["subject"].as_str().unwrap_or("(no subject)");
                         let body = msg["body"]
                             .as_str()
                             .or_else(|| msg["text_body"].as_str())
                             .unwrap_or("");
                         let preview = truncate_with_ellipsis(body, 100);
-                        lines.push(format!(
-                            "[{}] From: {} ({})\n  {}",
-                            i + 1,
-                            from,
-                            date,
-                            preview
-                        ));
+                        let mut message_lines = vec![
+                            format!("[{}] From: {}", i + 1, from),
+                            format!("  To: {}", to),
+                        ];
+                        if let Some(cc) = cc {
+                            message_lines.push(format!("  Cc: {}", cc));
+                        }
+                        if let Some(reply_to) = reply_to {
+                            message_lines.push(format!("  Reply-To: {}", reply_to));
+                        }
+                        message_lines.push(format!("  Date: {}", date));
+                        message_lines.push(format!("  Subject: {}", subject));
+                        message_lines.push(format!("  {}", preview));
+                        lines.push(message_lines.join("\n"));
                     }
                     let subject = data["subject"].as_str().unwrap_or("(thread)");
                     format!("Thread: {}\n{}", subject, lines.join("\n\n"))
@@ -7976,10 +8018,12 @@ mod tests {
 
     #[test]
     fn test_human_output_get_email() {
-        let text = r#"{"from": "alice@test.com", "to": "bob@test.com", "subject": "Hi", "date": "2024-01-01", "body": "Hello Bob"}"#;
+        let text = r#"{"from": "alice@test.com", "to": "bob@test.com", "cc": ["carol@test.com"], "reply_to": "replies@test.com", "subject": "Hi", "date": "2024-01-01", "body": "Hello Bob"}"#;
         let output = format_human_output("get_email", text);
         assert!(output.contains("From: alice@test.com"));
         assert!(output.contains("To: bob@test.com"));
+        assert!(output.contains("Cc: carol@test.com"));
+        assert!(output.contains("Reply-To: replies@test.com"));
         assert!(output.contains("Subject: Hi"));
         assert!(output.contains("Hello Bob"));
     }
@@ -7992,10 +8036,13 @@ mod tests {
 
     #[test]
     fn test_human_output_send_reply() {
-        let text = r#"{"message_id": "<reply@test>"}"#;
+        let text =
+            r#"{"message_id": "<reply@test>", "to": ["alice@test.com"], "cc": ["bob@test.com"]}"#;
         let output = format_human_output("send_reply", text);
         assert!(output.contains("Reply sent"));
         assert!(output.contains("<reply@test>"));
+        assert!(output.contains("To: alice@test.com"));
+        assert!(output.contains("Cc: bob@test.com"));
     }
 
     #[test]
@@ -8058,10 +8105,13 @@ mod tests {
 
     #[test]
     fn test_human_output_get_thread() {
-        let text = r#"{"subject": "Discussion", "messages": [{"from": "alice@test.com", "date": "2024-01-01", "body": "Hello"}, {"from": "bob@test.com", "date": "2024-01-02", "body": "Hi back"}]}"#;
+        let text = r#"{"subject": "Discussion", "messages": [{"from": "alice@test.com", "to": ["agent@test.com", "bob@test.com"], "cc": ["carol@test.com"], "reply_to": "replies@test.com", "date": "2024-01-01", "subject": "Discussion", "body": "Hello"}, {"from": "bob@test.com", "to": "agent@test.com", "date": "2024-01-02", "subject": "Re: Discussion", "body": "Hi back"}]}"#;
         let output = format_human_output("get_thread", text);
         assert!(output.contains("Thread: Discussion"));
         assert!(output.contains("[1] From: alice@test.com"));
+        assert!(output.contains("To: agent@test.com, bob@test.com"));
+        assert!(output.contains("Cc: carol@test.com"));
+        assert!(output.contains("Reply-To: replies@test.com"));
         assert!(output.contains("[2] From: bob@test.com"));
         assert!(output.contains("Hello"));
         assert!(output.contains("Hi back"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1992,12 +1992,14 @@ fn normalize_body_newlines(input: String) -> String {
 fn json_string_or_joined_array(value: &Value) -> Option<String> {
     value
         .as_str()
-        .map(|s| s.to_string())
+        .map(|s| s.trim().to_string())
         .or_else(|| {
             value.as_array().map(|items| {
                 items
                     .iter()
-                    .filter_map(|item| item.as_str().map(|s| s.to_string()))
+                    .filter_map(|item| item.as_str().map(str::trim))
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
                     .collect::<Vec<_>>()
                     .join(", ")
             })
@@ -2071,7 +2073,7 @@ fn format_human_output(tool_name: &str, text: &str) -> String {
                     .unwrap_or("unknown");
                 let to = json_string_or_joined_array(&email["to"]).unwrap_or_default();
                 let cc = json_string_or_joined_array(&email["cc"]);
-                let reply_to = email["reply_to"].as_str().filter(|s| !s.is_empty());
+                let reply_to = json_string_or_joined_array(&email["reply_to"]);
                 let subject = email["subject"].as_str().unwrap_or("(no subject)");
                 let date = email["date"]
                     .as_str()
@@ -2158,7 +2160,7 @@ fn format_human_output(tool_name: &str, text: &str) -> String {
                             .unwrap_or("unknown");
                         let to = json_string_or_joined_array(&msg["to"]).unwrap_or_default();
                         let cc = json_string_or_joined_array(&msg["cc"]);
-                        let reply_to = msg["reply_to"].as_str().filter(|s| !s.is_empty());
+                        let reply_to = json_string_or_joined_array(&msg["reply_to"]);
                         let date = msg["date"]
                             .as_str()
                             .or_else(|| msg["received_at"].as_str())
@@ -8018,12 +8020,12 @@ mod tests {
 
     #[test]
     fn test_human_output_get_email() {
-        let text = r#"{"from": "alice@test.com", "to": "bob@test.com", "cc": ["carol@test.com"], "reply_to": "replies@test.com", "subject": "Hi", "date": "2024-01-01", "body": "Hello Bob"}"#;
+        let text = r#"{"from": "alice@test.com", "to": "bob@test.com", "cc": ["carol@test.com"], "reply_to": ["replies@test.com", "backup@test.com"], "subject": "Hi", "date": "2024-01-01", "body": "Hello Bob"}"#;
         let output = format_human_output("get_email", text);
         assert!(output.contains("From: alice@test.com"));
         assert!(output.contains("To: bob@test.com"));
         assert!(output.contains("Cc: carol@test.com"));
-        assert!(output.contains("Reply-To: replies@test.com"));
+        assert!(output.contains("Reply-To: replies@test.com, backup@test.com"));
         assert!(output.contains("Subject: Hi"));
         assert!(output.contains("Hello Bob"));
     }
@@ -8105,16 +8107,29 @@ mod tests {
 
     #[test]
     fn test_human_output_get_thread() {
-        let text = r#"{"subject": "Discussion", "messages": [{"from": "alice@test.com", "to": ["agent@test.com", "bob@test.com"], "cc": ["carol@test.com"], "reply_to": "replies@test.com", "date": "2024-01-01", "subject": "Discussion", "body": "Hello"}, {"from": "bob@test.com", "to": "agent@test.com", "date": "2024-01-02", "subject": "Re: Discussion", "body": "Hi back"}]}"#;
+        let text = r#"{"subject": "Discussion", "messages": [{"from": "alice@test.com", "to": ["agent@test.com", "bob@test.com"], "cc": ["carol@test.com"], "reply_to": ["replies@test.com", "backup@test.com"], "date": "2024-01-01", "subject": "Discussion", "body": "Hello"}, {"from": "bob@test.com", "to": "agent@test.com", "date": "2024-01-02", "subject": "Re: Discussion", "body": "Hi back"}]}"#;
         let output = format_human_output("get_thread", text);
         assert!(output.contains("Thread: Discussion"));
         assert!(output.contains("[1] From: alice@test.com"));
         assert!(output.contains("To: agent@test.com, bob@test.com"));
         assert!(output.contains("Cc: carol@test.com"));
-        assert!(output.contains("Reply-To: replies@test.com"));
+        assert!(output.contains("Reply-To: replies@test.com, backup@test.com"));
         assert!(output.contains("[2] From: bob@test.com"));
         assert!(output.contains("Hello"));
         assert!(output.contains("Hi back"));
+    }
+
+    #[test]
+    fn test_json_string_or_joined_array_trims_and_filters_empty_values() {
+        assert_eq!(
+            json_string_or_joined_array(&json!(["  alice@test.com  ", "", " ", "bob@test.com"])),
+            Some("alice@test.com, bob@test.com".to_string())
+        );
+        assert_eq!(json_string_or_joined_array(&json!(["", "  "])), None);
+        assert_eq!(
+            json_string_or_joined_array(&json!("  carol@test.com  ")),
+            Some("carol@test.com".to_string())
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2158,7 +2158,7 @@ fn format_human_output(tool_name: &str, text: &str) -> String {
                             .as_str()
                             .or_else(|| msg["sender"].as_str())
                             .unwrap_or("unknown");
-                        let to = json_string_or_joined_array(&msg["to"]).unwrap_or_default();
+                        let to = json_string_or_joined_array(&msg["to"]);
                         let cc = json_string_or_joined_array(&msg["cc"]);
                         let reply_to = json_string_or_joined_array(&msg["reply_to"]);
                         let date = msg["date"]
@@ -2171,10 +2171,10 @@ fn format_human_output(tool_name: &str, text: &str) -> String {
                             .or_else(|| msg["text_body"].as_str())
                             .unwrap_or("");
                         let preview = truncate_with_ellipsis(body, 100);
-                        let mut message_lines = vec![
-                            format!("[{}] From: {}", i + 1, from),
-                            format!("  To: {}", to),
-                        ];
+                        let mut message_lines = vec![format!("[{}] From: {}", i + 1, from)];
+                        if let Some(to) = to {
+                            message_lines.push(format!("  To: {}", to));
+                        }
                         if let Some(cc) = cc {
                             message_lines.push(format!("  Cc: {}", cc));
                         }
@@ -8142,6 +8142,14 @@ mod tests {
         let output = format_human_output("get_thread", &text);
         assert!(output.contains("..."));
         assert!(output.contains(&"x".repeat(100)));
+    }
+
+    #[test]
+    fn test_human_output_get_thread_omits_blank_to_line() {
+        let text = r#"{"messages": [{"from": "a@b.com", "date": "2024-01-01", "subject": "Test", "body": "Hello"}]}"#;
+        let output = format_human_output("get_thread", text);
+        assert!(!output.contains("  To: "));
+        assert!(output.contains("Subject: Test"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- show To/Cc/Reply-To in get_email and get_thread human output
- include resolved reply recipients in send_reply human output
- update reply skills and send guard to make multi-recipient replies explicit

## Verification
- cargo fmt
- cargo clippy -- -D warnings
- cargo test
- cargo build
- cargo run -- get-emails --limit 1 --human