### PR TITLE
fix(send-reply): treat whitespace-only bodies as empty

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5652,7 +5652,13 @@ mod tests {
         })]);
         let result = rewrite_tools_list(&body, None);
         let parsed: Value = serde_json::from_str(&result).unwrap();
-        let tool = &parsed["result"]["tools"][0];
+        let tools = parsed["result"]["tools"]
+            .as_array()
+            .expect("rewritten tools list should be an array");
+        let tool = tools
+            .iter()
+            .find(|tool| tool["name"] == "account_create")
+            .expect("account_create should remain present");
 
         assert_eq!(tool["description"], AUTH_TOOL_OVERRIDE);
         assert_eq!(tool["inputSchema"]["type"], "object");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1773,8 +1773,8 @@ async fn verify_send_reply_delivery(
     let mut last_verify_error: Option<anyhow::Error> = None;
     let mut saw_matching_message = false;
 
-    for attempt in 0..SEND_REPLY_VERIFY_ATTEMPTS {
-        match call_mcp_tool(
+    for attempt in 1..=SEND_REPLY_VERIFY_ATTEMPTS {
+        let sent_response = match call_mcp_tool(
             endpoint,
             creds,
             http_client,
@@ -1783,49 +1783,66 @@ async fn verify_send_reply_delivery(
         )
         .await
         {
-            Ok(response) => match extract_tool_result_text(&response) {
-                Ok(sent_text) => match serde_json::from_str::<Value>(&sent_text) {
-                    Ok(sent_items) => {
-                        if let Some(message) = find_recent_sent_message(&sent_items, &message_id) {
-                            saw_matching_message = true;
-                            if message_has_visible_body(message) {
-                                return Ok(());
-                            }
-                            if let Ok(email_response) = call_mcp_tool(
-                                endpoint,
-                                creds,
-                                http_client,
-                                "get_email",
-                                json!({"message_id": message_id, "content_format": "all"}),
-                            )
-                            .await
-                            {
-                                if let Ok(email_text) = extract_tool_result_text(&email_response) {
-                                    if let Ok(email) = serde_json::from_str::<Value>(&email_text) {
-                                        if message_has_visible_body(&email) {
-                                            return Ok(());
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        last_verify_error = Some(anyhow!(
-                                "get_sent_emails returned non-JSON payload during send-reply verification: {err}"
-                            ));
-                    }
-                },
-                Err(err) => {
-                    last_verify_error = Some(err);
-                }
-            },
+            Ok(response) => response,
             Err(err) => {
                 last_verify_error = Some(err);
+                if attempt < SEND_REPLY_VERIFY_ATTEMPTS {
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+                continue;
+            }
+        };
+
+        let sent_text = match extract_tool_result_text(&sent_response) {
+            Ok(text) => text,
+            Err(err) => {
+                last_verify_error = Some(err);
+                if attempt < SEND_REPLY_VERIFY_ATTEMPTS {
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+                continue;
+            }
+        };
+
+        let sent_items = match serde_json::from_str::<Value>(&sent_text) {
+            Ok(value) => value,
+            Err(err) => {
+                last_verify_error = Some(anyhow!(
+                    "get_sent_emails returned non-JSON payload during send-reply verification: {err}"
+                ));
+                if attempt < SEND_REPLY_VERIFY_ATTEMPTS {
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+                continue;
+            }
+        };
+
+        if let Some(message) = find_recent_sent_message(&sent_items, &message_id) {
+            saw_matching_message = true;
+            if message_has_visible_body(message) {
+                return Ok(());
+            }
+
+            if let Ok(email_response) = call_mcp_tool(
+                endpoint,
+                creds,
+                http_client,
+                "get_email",
+                json!({"message_id": message_id, "content_format": "all"}),
+            )
+            .await
+            {
+                if let Ok(email_text) = extract_tool_result_text(&email_response) {
+                    if let Ok(email) = serde_json::from_str::<Value>(&email_text) {
+                        if message_has_visible_body(&email) {
+                            return Ok(());
+                        }
+                    }
+                }
             }
         }
 
-        if attempt + 1 < SEND_REPLY_VERIFY_ATTEMPTS {
+        if attempt < SEND_REPLY_VERIFY_ATTEMPTS {
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1748,36 +1748,45 @@ async fn verify_send_reply_delivery(
         {
             Ok(response) => match extract_tool_result_text(&response) {
                 Ok(sent_text) => {
-                    if let Ok(sent_items) = serde_json::from_str::<Value>(&sent_text) {
-                        if let Some(message) = find_recent_sent_message(&sent_items, &message_id) {
-                            saw_matching_message = true;
-                            if message_has_visible_body(message) {
-                                return Ok(());
-                            }
-                            if let Ok(email_response) = call_mcp_tool(
-                                endpoint,
-                                creds,
-                                http_client,
-                                "get_email",
-                                json!({"message_id": message_id, "content_format": "all"}),
-                            )
-                            .await
+                    match serde_json::from_str::<Value>(&sent_text) {
+                        Ok(sent_items) => {
+                            if let Some(message) = find_recent_sent_message(&sent_items, &message_id)
                             {
-                                if let Ok(email_text) = extract_tool_result_text(&email_response) {
-                                    if let Ok(email) = serde_json::from_str::<Value>(&email_text) {
-                                        if message_has_visible_body(&email) {
-                                            return Ok(());
+                                saw_matching_message = true;
+                                if message_has_visible_body(message) {
+                                    return Ok(());
+                                }
+                                if let Ok(email_response) = call_mcp_tool(
+                                    endpoint,
+                                    creds,
+                                    http_client,
+                                    "get_email",
+                                    json!({"message_id": message_id, "content_format": "all"}),
+                                )
+                                .await
+                                {
+                                    if let Ok(email_text) = extract_tool_result_text(&email_response) {
+                                        if let Ok(email) = serde_json::from_str::<Value>(&email_text)
+                                        {
+                                            if message_has_visible_body(&email) {
+                                                return Ok(());
+                                            }
                                         }
                                     }
                                 }
+                                if attempt + 1 == SEND_REPLY_VERIFY_ATTEMPTS {
+                                    return finalize_send_reply_verification(
+                                        &message_id,
+                                        saw_matching_message,
+                                        last_verify_error,
+                                    );
+                                }
                             }
-                            if attempt + 1 == SEND_REPLY_VERIFY_ATTEMPTS {
-                                return finalize_send_reply_verification(
-                                    &message_id,
-                                    saw_matching_message,
-                                    last_verify_error,
-                                );
-                            }
+                        }
+                        Err(err) => {
+                            last_verify_error = Some(anyhow!(
+                                "get_sent_emails returned non-JSON payload during send-reply verification: {err}"
+                            ));
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1676,7 +1676,7 @@ fn message_has_visible_body(message: &Value) -> bool {
         .as_str()
         .or_else(|| message["htmlBody"].as_str())
         .unwrap_or_default();
-    !body.is_empty() || !html_body.is_empty()
+    !body.trim().is_empty() || !html_body.trim().is_empty()
 }
 
 fn sent_email_items(sent_items: &Value) -> Option<&Vec<Value>> {
@@ -7152,6 +7152,10 @@ mod tests {
         assert!(
             !message_has_visible_body(&json!({"body": "", "html_body": ""})),
             "empty plain/html bodies should not count as visible content"
+        );
+        assert!(
+            !message_has_visible_body(&json!({"body": "   ", "html_body": "\n\t"})),
+            "whitespace-only bodies should not count as visible content"
         );
         assert!(
             !message_has_visible_body(&json!({})),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1707,51 +1707,70 @@ async fn verify_send_reply_delivery(
     };
 
     const SEND_REPLY_VERIFY_ATTEMPTS: usize = 6;
+    let mut last_verify_error: Option<anyhow::Error> = None;
 
     for attempt in 0..SEND_REPLY_VERIFY_ATTEMPTS {
-        let response = call_mcp_tool(
+        match call_mcp_tool(
             endpoint,
             creds,
             http_client,
             "get_sent_emails",
             json!({"limit": 10}),
         )
-        .await?;
-        let sent_text = extract_tool_result_text(&response)?;
-        if let Ok(sent_items) = serde_json::from_str::<Value>(&sent_text) {
-            if let Some(message) = find_recent_sent_message(&sent_items, &message_id) {
-                if message_has_visible_body(message) {
-                    return Ok(());
-                }
-                if let Ok(email_response) = call_mcp_tool(
-                    endpoint,
-                    creds,
-                    http_client,
-                    "get_email",
-                    json!({"message_id": message_id, "content_format": "all"}),
-                )
-                .await
-                {
-                    if let Ok(email_text) = extract_tool_result_text(&email_response) {
-                        if let Ok(email) = serde_json::from_str::<Value>(&email_text) {
-                            if message_has_visible_body(&email) {
+        .await
+        {
+            Ok(response) => match extract_tool_result_text(&response) {
+                Ok(sent_text) => {
+                    if let Ok(sent_items) = serde_json::from_str::<Value>(&sent_text) {
+                        if let Some(message) = find_recent_sent_message(&sent_items, &message_id) {
+                            if message_has_visible_body(message) {
                                 return Ok(());
+                            }
+                            if let Ok(email_response) = call_mcp_tool(
+                                endpoint,
+                                creds,
+                                http_client,
+                                "get_email",
+                                json!({"message_id": message_id, "content_format": "all"}),
+                            )
+                            .await
+                            {
+                                if let Ok(email_text) = extract_tool_result_text(&email_response) {
+                                    if let Ok(email) = serde_json::from_str::<Value>(&email_text) {
+                                        if message_has_visible_body(&email) {
+                                            return Ok(());
+                                        }
+                                    }
+                                }
+                            }
+                            if attempt + 1 == SEND_REPLY_VERIFY_ATTEMPTS {
+                                return Err(anyhow!(
+                                    "send-reply reported success, but sent message {} has an empty body",
+                                    message_id
+                                ));
                             }
                         }
                     }
                 }
-                if attempt + 1 == SEND_REPLY_VERIFY_ATTEMPTS {
-                    return Err(anyhow!(
-                        "send-reply reported success, but sent message {} has an empty body",
-                        message_id
-                    ));
+                Err(err) => {
+                    last_verify_error = Some(err);
                 }
+            },
+            Err(err) => {
+                last_verify_error = Some(err);
             }
         }
 
         if attempt + 1 < SEND_REPLY_VERIFY_ATTEMPTS {
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
+    }
+
+    if let Some(err) = last_verify_error {
+        return Err(err.context(format!(
+            "send-reply verification could not confirm sent message {}",
+            message_id
+        )));
     }
 
     Ok(())
@@ -7032,7 +7051,11 @@ mod tests {
     #[test]
     fn test_extract_message_id_from_send_reply_result() {
         let text = r#"{"message_id":"<reply@test>","status":"queued"}"#;
-        assert_eq!(extract_message_id(text).as_deref(), Some("<reply@test>"));
+        assert_eq!(
+            extract_message_id(text).as_deref(),
+            Some("<reply@test>"),
+            "queued send_reply response should expose the generated reply message id"
+        );
     }
 
     #[test]
@@ -7041,8 +7064,12 @@ mod tests {
             {"message_id": "<one@test>", "body": "first"},
             {"message_id": "<two@test>", "body": "second"}
         ]);
-        let message = find_recent_sent_message(&sent_items, "<two@test>").unwrap();
-        assert_eq!(message["body"], "second");
+        let message = find_recent_sent_message(&sent_items, "<two@test>")
+            .expect("expected recent sent message lookup to match bare message_id");
+        assert_eq!(
+            message["body"], "second",
+            "sent message lookup should return the matching entry body"
+        );
     }
 
     #[test]
@@ -7055,22 +7082,40 @@ mod tests {
             ],
             "returned": 2
         });
-        let message = find_recent_sent_message(&sent_items, "<two@test>").unwrap();
-        assert_eq!(message["body"], "second");
+        let message = find_recent_sent_message(&sent_items, "<two@test>")
+            .expect("expected recent sent message lookup to unwrap sent_emails response shape");
+        assert_eq!(
+            message["body"], "second",
+            "sent message lookup should return wrapped sent_emails entry body"
+        );
     }
 
     #[test]
     fn test_message_has_visible_body_accepts_plain_or_html() {
-        assert!(message_has_visible_body(&json!({"body": "reply"})));
-        assert!(message_has_visible_body(&json!({"text_body": "reply"})));
-        assert!(message_has_visible_body(&json!({"textBody": "reply"})));
-        assert!(message_has_visible_body(
-            &json!({"html_body": "<p>reply</p>"})
-        ));
-        assert!(!message_has_visible_body(
-            &json!({"body": "", "html_body": ""})
-        ));
-        assert!(!message_has_visible_body(&json!({})));
+        assert!(
+            message_has_visible_body(&json!({"body": "reply"})),
+            "plain body should count as visible content"
+        );
+        assert!(
+            message_has_visible_body(&json!({"text_body": "reply"})),
+            "text_body should count as visible content"
+        );
+        assert!(
+            message_has_visible_body(&json!({"textBody": "reply"})),
+            "textBody should count as visible content"
+        );
+        assert!(
+            message_has_visible_body(&json!({"html_body": "<p>reply</p>"})),
+            "html_body should count as visible content"
+        );
+        assert!(
+            !message_has_visible_body(&json!({"body": "", "html_body": ""})),
+            "empty plain/html bodies should not count as visible content"
+        );
+        assert!(
+            !message_has_visible_body(&json!({})),
+            "missing body fields should not count as visible content"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1696,6 +1696,32 @@ fn find_recent_sent_message<'a>(sent_items: &'a Value, message_id: &str) -> Opti
     })
 }
 
+fn finalize_send_reply_verification(
+    message_id: &str,
+    saw_matching_message: bool,
+    last_verify_error: Option<anyhow::Error>,
+) -> Result<()> {
+    if saw_matching_message {
+        return Err(anyhow!(
+            "send-reply reported success, but sent message {} has an empty body",
+            message_id
+        ));
+    }
+
+    if let Some(err) = last_verify_error {
+        return Err(anyhow!(
+            "send-reply verification could not confirm sent message {}: {:#}",
+            message_id,
+            err
+        ));
+    }
+
+    Err(anyhow!(
+        "send-reply reported success, but sent message {} was not found in sent items after verification retries",
+        message_id
+    ))
+}
+
 async fn verify_send_reply_delivery(
     endpoint: &str,
     creds: &mut Option<Credentials>,
@@ -1708,6 +1734,7 @@ async fn verify_send_reply_delivery(
 
     const SEND_REPLY_VERIFY_ATTEMPTS: usize = 6;
     let mut last_verify_error: Option<anyhow::Error> = None;
+    let mut saw_matching_message = false;
 
     for attempt in 0..SEND_REPLY_VERIFY_ATTEMPTS {
         match call_mcp_tool(
@@ -1723,6 +1750,7 @@ async fn verify_send_reply_delivery(
                 Ok(sent_text) => {
                     if let Ok(sent_items) = serde_json::from_str::<Value>(&sent_text) {
                         if let Some(message) = find_recent_sent_message(&sent_items, &message_id) {
+                            saw_matching_message = true;
                             if message_has_visible_body(message) {
                                 return Ok(());
                             }
@@ -1744,10 +1772,11 @@ async fn verify_send_reply_delivery(
                                 }
                             }
                             if attempt + 1 == SEND_REPLY_VERIFY_ATTEMPTS {
-                                return Err(anyhow!(
-                                    "send-reply reported success, but sent message {} has an empty body",
-                                    message_id
-                                ));
+                                return finalize_send_reply_verification(
+                                    &message_id,
+                                    saw_matching_message,
+                                    last_verify_error,
+                                );
                             }
                         }
                     }
@@ -1766,14 +1795,7 @@ async fn verify_send_reply_delivery(
         }
     }
 
-    if let Some(err) = last_verify_error {
-        return Err(err.context(format!(
-            "send-reply verification could not confirm sent message {}",
-            message_id
-        )));
-    }
-
-    Ok(())
+    finalize_send_reply_verification(&message_id, saw_matching_message, last_verify_error)
 }
 
 /// Split a comma-separated string into a Vec of trimmed strings.
@@ -7129,6 +7151,37 @@ mod tests {
         assert!(
             !message_has_visible_body(&json!({})),
             "missing body fields should not count as visible content"
+        );
+    }
+
+    #[test]
+    fn test_finalize_send_reply_verification_reports_missing_message() {
+        let err = finalize_send_reply_verification("<reply@test>", false, None)
+            .expect_err("missing sent message should fail verification");
+        assert!(
+            err.to_string()
+                .contains("was not found in sent items after verification retries"),
+            "missing sent message should explain that verification never found the reply"
+        );
+    }
+
+    #[test]
+    fn test_finalize_send_reply_verification_prefers_transport_error_before_missing_message() {
+        let err = finalize_send_reply_verification(
+            "<reply@test>",
+            false,
+            Some(anyhow!("temporary sent-items failure")),
+        )
+        .expect_err("transport failures should surface verification context");
+        let err_text = format!("{err:#}");
+        assert!(
+            err_text
+                .contains("send-reply verification could not confirm sent message <reply@test>"),
+            "verification errors should be wrapped with message-id context"
+        );
+        assert!(
+            err_text.contains("temporary sent-items failure"),
+            "wrapped verification error should preserve the original failure reason"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1771,13 +1771,6 @@ async fn verify_send_reply_delivery(
                                     }
                                 }
                             }
-                            if attempt + 1 == SEND_REPLY_VERIFY_ATTEMPTS {
-                                return finalize_send_reply_verification(
-                                    &message_id,
-                                    saw_matching_message,
-                                    last_verify_error,
-                                );
-                            }
                         }
                     }
                     Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1747,49 +1747,45 @@ async fn verify_send_reply_delivery(
         .await
         {
             Ok(response) => match extract_tool_result_text(&response) {
-                Ok(sent_text) => {
-                    match serde_json::from_str::<Value>(&sent_text) {
-                        Ok(sent_items) => {
-                            if let Some(message) = find_recent_sent_message(&sent_items, &message_id)
+                Ok(sent_text) => match serde_json::from_str::<Value>(&sent_text) {
+                    Ok(sent_items) => {
+                        if let Some(message) = find_recent_sent_message(&sent_items, &message_id) {
+                            saw_matching_message = true;
+                            if message_has_visible_body(message) {
+                                return Ok(());
+                            }
+                            if let Ok(email_response) = call_mcp_tool(
+                                endpoint,
+                                creds,
+                                http_client,
+                                "get_email",
+                                json!({"message_id": message_id, "content_format": "all"}),
+                            )
+                            .await
                             {
-                                saw_matching_message = true;
-                                if message_has_visible_body(message) {
-                                    return Ok(());
-                                }
-                                if let Ok(email_response) = call_mcp_tool(
-                                    endpoint,
-                                    creds,
-                                    http_client,
-                                    "get_email",
-                                    json!({"message_id": message_id, "content_format": "all"}),
-                                )
-                                .await
-                                {
-                                    if let Ok(email_text) = extract_tool_result_text(&email_response) {
-                                        if let Ok(email) = serde_json::from_str::<Value>(&email_text)
-                                        {
-                                            if message_has_visible_body(&email) {
-                                                return Ok(());
-                                            }
+                                if let Ok(email_text) = extract_tool_result_text(&email_response) {
+                                    if let Ok(email) = serde_json::from_str::<Value>(&email_text) {
+                                        if message_has_visible_body(&email) {
+                                            return Ok(());
                                         }
                                     }
                                 }
-                                if attempt + 1 == SEND_REPLY_VERIFY_ATTEMPTS {
-                                    return finalize_send_reply_verification(
-                                        &message_id,
-                                        saw_matching_message,
-                                        last_verify_error,
-                                    );
-                                }
+                            }
+                            if attempt + 1 == SEND_REPLY_VERIFY_ATTEMPTS {
+                                return finalize_send_reply_verification(
+                                    &message_id,
+                                    saw_matching_message,
+                                    last_verify_error,
+                                );
                             }
                         }
-                        Err(err) => {
-                            last_verify_error = Some(anyhow!(
+                    }
+                    Err(err) => {
+                        last_verify_error = Some(anyhow!(
                                 "get_sent_emails returned non-JSON payload during send-reply verification: {err}"
                             ));
-                        }
                     }
-                }
+                },
                 Err(err) => {
                     last_verify_error = Some(err);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5638,8 +5638,16 @@ mod tests {
             "get_emails should have untrusted warning"
         );
         assert!(get_emails_desc.contains("Fetch emails from your inbox"));
-        assert_eq!(tools[1]["description"], "Show help text");
-        assert_eq!(tools[2]["description"], AUTH_TOOL_OVERRIDE); // account_create
+        let help = tools
+            .iter()
+            .find(|tool| tool["name"].as_str() == Some("help"))
+            .expect("help should remain present");
+        assert_eq!(help["description"], "Show help text");
+        let account_create = tools
+            .iter()
+            .find(|tool| tool["name"].as_str() == Some("account_create"))
+            .expect("account_create should remain present");
+        assert_eq!(account_create["description"], AUTH_TOOL_OVERRIDE);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1658,6 +1658,105 @@ fn extract_tool_result_text(response: &Value) -> Result<String> {
         .ok_or_else(|| anyhow!("No text content in response"))
 }
 
+fn extract_message_id(text: &str) -> Option<String> {
+    let data: Value = serde_json::from_str(text).ok()?;
+    data["message_id"]
+        .as_str()
+        .or_else(|| data["messageId"].as_str())
+        .map(ToOwned::to_owned)
+}
+
+fn message_has_visible_body(message: &Value) -> bool {
+    let body = message["body"]
+        .as_str()
+        .or_else(|| message["text_body"].as_str())
+        .or_else(|| message["textBody"].as_str())
+        .unwrap_or_default();
+    let html_body = message["html_body"]
+        .as_str()
+        .or_else(|| message["htmlBody"].as_str())
+        .unwrap_or_default();
+    !body.is_empty() || !html_body.is_empty()
+}
+
+fn sent_email_items(sent_items: &Value) -> Option<&Vec<Value>> {
+    sent_items
+        .as_array()
+        .or_else(|| sent_items["sent_emails"].as_array())
+        .or_else(|| sent_items["emails"].as_array())
+        .or_else(|| sent_items["results"].as_array())
+}
+
+fn find_recent_sent_message<'a>(sent_items: &'a Value, message_id: &str) -> Option<&'a Value> {
+    sent_email_items(sent_items)?.iter().find(|item| {
+        item["message_id"]
+            .as_str()
+            .or_else(|| item["messageId"].as_str())
+            .is_some_and(|id| id == message_id)
+    })
+}
+
+async fn verify_send_reply_delivery(
+    endpoint: &str,
+    creds: &mut Option<Credentials>,
+    http_client: &HttpClient,
+    response_text: &str,
+) -> Result<()> {
+    let Some(message_id) = extract_message_id(response_text) else {
+        return Ok(());
+    };
+
+    const SEND_REPLY_VERIFY_ATTEMPTS: usize = 6;
+
+    for attempt in 0..SEND_REPLY_VERIFY_ATTEMPTS {
+        let response = call_mcp_tool(
+            endpoint,
+            creds,
+            http_client,
+            "get_sent_emails",
+            json!({"limit": 10}),
+        )
+        .await?;
+        let sent_text = extract_tool_result_text(&response)?;
+        if let Ok(sent_items) = serde_json::from_str::<Value>(&sent_text) {
+            if let Some(message) = find_recent_sent_message(&sent_items, &message_id) {
+                if message_has_visible_body(message) {
+                    return Ok(());
+                }
+                if let Ok(email_response) = call_mcp_tool(
+                    endpoint,
+                    creds,
+                    http_client,
+                    "get_email",
+                    json!({"message_id": message_id, "content_format": "all"}),
+                )
+                .await
+                {
+                    if let Ok(email_text) = extract_tool_result_text(&email_response) {
+                        if let Ok(email) = serde_json::from_str::<Value>(&email_text) {
+                            if message_has_visible_body(&email) {
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+                if attempt + 1 == SEND_REPLY_VERIFY_ATTEMPTS {
+                    return Err(anyhow!(
+                        "send-reply reported success, but sent message {} has an empty body",
+                        message_id
+                    ));
+                }
+            }
+        }
+
+        if attempt + 1 < SEND_REPLY_VERIFY_ATTEMPTS {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    Ok(())
+}
+
 /// Split a comma-separated string into a Vec of trimmed strings.
 fn split_csv(s: &str) -> Vec<String> {
     s.split(',')
@@ -2595,6 +2694,7 @@ async fn run_cli_command(cli: &Cli) -> Result<()> {
             let response =
                 call_mcp_tool(&endpoint, &mut creds, &http_client, "send_reply", args).await?;
             let text = extract_tool_result_text(&response)?;
+            verify_send_reply_delivery(&endpoint, &mut creds, &http_client, &text).await?;
             print_result("send_reply", &text, cli.human);
         }
         Some(Commands::ForwardEmail {
@@ -6927,6 +7027,50 @@ mod tests {
         assert_eq!(attachments[1]["filename"], "photo.jpg");
         assert_eq!(attachments[1]["content_type"], "image/jpeg");
         assert_eq!(args["token"], "tok");
+    }
+
+    #[test]
+    fn test_extract_message_id_from_send_reply_result() {
+        let text = r#"{"message_id":"<reply@test>","status":"queued"}"#;
+        assert_eq!(extract_message_id(text).as_deref(), Some("<reply@test>"));
+    }
+
+    #[test]
+    fn test_find_recent_sent_message_matches_message_id() {
+        let sent_items = json!([
+            {"message_id": "<one@test>", "body": "first"},
+            {"message_id": "<two@test>", "body": "second"}
+        ]);
+        let message = find_recent_sent_message(&sent_items, "<two@test>").unwrap();
+        assert_eq!(message["body"], "second");
+    }
+
+    #[test]
+    fn test_find_recent_sent_message_matches_wrapped_sent_emails() {
+        let sent_items = json!({
+            "total": 2,
+            "sent_emails": [
+                {"message_id": "<one@test>", "body": "first"},
+                {"message_id": "<two@test>", "body": "second"}
+            ],
+            "returned": 2
+        });
+        let message = find_recent_sent_message(&sent_items, "<two@test>").unwrap();
+        assert_eq!(message["body"], "second");
+    }
+
+    #[test]
+    fn test_message_has_visible_body_accepts_plain_or_html() {
+        assert!(message_has_visible_body(&json!({"body": "reply"})));
+        assert!(message_has_visible_body(&json!({"text_body": "reply"})));
+        assert!(message_has_visible_body(&json!({"textBody": "reply"})));
+        assert!(message_has_visible_body(
+            &json!({"html_body": "<p>reply</p>"})
+        ));
+        assert!(!message_has_visible_body(
+            &json!({"body": "", "html_body": ""})
+        ));
+        assert!(!message_has_visible_body(&json!({})));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- treat whitespace-only `body` / `html_body` values as empty in send-reply verification
- add regression assertion covering whitespace-only body payloads

## Why
`send_reply` verification should fail when stored content is effectively empty. Prior logic accepted strings like spaces/newlines as visible body content.

## Validation
- attempted: `cargo test message_has_visible_body -- --nocapture`
- blocked in this environment: missing linker `cc` (`error: linker \`cc\` not found`)

## Follow-up
- run targeted and full test suite in CI or a dev env with build-essential installed.
