### PR TITLE
fix(mcp): normalize no-arg tool schemas for OpenAI compatibility

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7563,10 +7563,24 @@ mod tests {
         let result = rewrite_tools_list(&body, None);
         let parsed: Value = serde_json::from_str(&result).unwrap();
         let input = &parsed["result"]["tools"][0]["inputSchema"];
-        assert_eq!(input["type"], "object");
-        assert_eq!(input["properties"], json!({}));
-        assert_eq!(input["required"], json!([]));
-        assert_eq!(input["additionalProperties"], false);
+        assert_eq!(
+            input["type"], "object",
+            "inputSchema type should remain object"
+        );
+        assert_eq!(
+            input["properties"],
+            json!({}),
+            "no-arg object schema should gain empty properties"
+        );
+        assert_eq!(
+            input["required"],
+            json!([]),
+            "no-arg object schema should gain empty required array"
+        );
+        assert_eq!(
+            input["additionalProperties"], false,
+            "no-arg object schema should default additionalProperties to false"
+        );
     }
 
     #[test]
@@ -7591,8 +7605,8 @@ mod tests {
         let result = rewrite_tools_list(&body, None);
         let parsed: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(
-            parsed["result"]["tools"][0]["inputSchema"]["additionalProperties"],
-            true
+            parsed["result"]["tools"][0]["inputSchema"]["additionalProperties"], true,
+            "existing additionalProperties value should be preserved"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4566,6 +4566,20 @@ fn rewrite_tools_list(body: &str, creds: Option<&Credentials>) -> String {
 
                 // Strip `token` and `encryption_secret` from every tool's inputSchema
                 if let Some(schema) = tool.get_mut("inputSchema").and_then(|s| s.as_object_mut()) {
+                    // Normalize no-arg object schemas so OpenAI-style function conversion
+                    // always gets an explicit `properties` object.
+                    if schema.get("type").and_then(|t| t.as_str()) == Some("object") {
+                        schema
+                            .entry("properties".to_string())
+                            .or_insert_with(|| json!({}));
+                        schema
+                            .entry("required".to_string())
+                            .or_insert_with(|| json!([]));
+                        schema
+                            .entry("additionalProperties".to_string())
+                            .or_insert_with(|| json!(false));
+                    }
+
                     // Add proxy-only confirmation flags / validation hints
                     if let Some(ref name) = tool_name {
                         if name == "forward_email" {
@@ -7528,6 +7542,57 @@ mod tests {
         assert_eq!(
             tool["inputSchema"]["properties"]["message_id"]["maxLength"],
             5000
+        );
+    }
+
+    #[test]
+    fn test_rewrite_tools_list_normalizes_no_arg_schema() {
+        let body = serde_json::to_string(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "tools": [{
+                    "name": "help",
+                    "description": "Help",
+                    "inputSchema": {"type": "object"}
+                }]
+            }
+        }))
+        .unwrap();
+
+        let result = rewrite_tools_list(&body, None);
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        let input = &parsed["result"]["tools"][0]["inputSchema"];
+        assert_eq!(input["type"], "object");
+        assert_eq!(input["properties"], json!({}));
+        assert_eq!(input["required"], json!([]));
+        assert_eq!(input["additionalProperties"], false);
+    }
+
+    #[test]
+    fn test_rewrite_tools_list_keeps_existing_additional_properties() {
+        let body = serde_json::to_string(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "tools": [{
+                    "name": "help",
+                    "description": "Help",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    }
+                }]
+            }
+        }))
+        .unwrap();
+
+        let result = rewrite_tools_list(&body, None);
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(
+            parsed["result"]["tools"][0]["inputSchema"]["additionalProperties"],
+            true
         );
     }
 


### PR DESCRIPTION
## Summary
Fixes #106 by normalizing MCP tool `inputSchema` objects in CLI proxy `tools/list` rewrite so no-arg tools are always emitted with explicit OpenAI-compatible object fields.

## What changed
- In `rewrite_tools_list`, for any `inputSchema` where `type == "object"`, ensure defaults:
  - `properties: {}`
  - `required: []`
  - `additionalProperties: false`
- Added regression tests for:
  - bare no-arg schema `{ "type": "object" }` normalization
  - preserving pre-existing `additionalProperties`

## Why
OpenAI/Codex rejects object schemas lacking `properties`. Some zero-arg tools (for example `help`) can currently pass through as `{ "type": "object" }`, which breaks tool ingestion.

## Validation
- Added focused tests in `src/main.rs`.
- Could not execute tests in this environment because toolchain linker is unavailable: `linker 'cc' not found`.
