### PR TITLE
feat(cli): add archive-email alias for delete-email

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '25 4 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [rust]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Build
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/README.md
+++ b/README.md
@@ -190,11 +190,13 @@ inboxapi get-email "<message-id>"
 
 ### `delete-email`
 
-Soft-deletes a received email by message ID. It prompts for confirmation by default, and scripted or piped use must pass `--force`.
+Archives (soft-deletes) a received email by message ID. It prompts for confirmation by default, and scripted or piped use must pass `--force`.
+`archive-email` is available as an alias for `delete-email`.
 
 ```bash
 inboxapi delete-email "<message-id>"
 inboxapi delete-email "<message-id>" --force
+inboxapi archive-email "<message-id>" --force
 ```
 
 ### `search-emails`

--- a/docs/help.md
+++ b/docs/help.md
@@ -21,6 +21,7 @@ inboxapi send-email --to user@example.com --subject "Hello" --body "Hi there"
 inboxapi send-email --to user@example.com --subject "Newsletter" --body-file ./body.txt --html-body-file ./newsletter.html
 inboxapi get-emails --limit 5 --human
 inboxapi delete-email "<message-id>" --force
+inboxapi archive-email "<message-id>" --force
 inboxapi search-emails --subject "invoice"
 inboxapi help
 ```
@@ -78,6 +79,7 @@ Your InboxAPI email address (from `whoami`) is **the agent's own inbox** for rec
 ## Deleting Received Email
 
 Use `delete_email` to hide a received message from the normal inbox views. This is a soft delete: the message is removed from `get_last_email`, `get_emails`, `get_email`, `search_emails`, `get_email_count`, and `get_thread`, but there is no restore or trash command yet.
+For CLI usage, `archive-email` is an alias for `delete-email`.
 
 The CLI prompts for confirmation by default. If stdin is not a TTY, you must pass `--force` or it will error instead of deleting.
 
@@ -86,6 +88,7 @@ CLI example:
 ```bash
 inboxapi delete-email "<message-id>"
 inboxapi delete-email "<message-id>" --force
+inboxapi archive-email "<message-id>" --force
 ```
 
 ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,8 @@ enum Commands {
         /// The message ID to retrieve
         message_id: String,
     },
-    /// Soft-delete a received email by message ID
+    /// Archive (soft-delete) a received email by message ID
+    #[command(visible_alias = "archive-email")]
     DeleteEmail {
         /// The message ID to delete
         message_id: String,
@@ -2513,7 +2514,7 @@ Commands:
   send-email     Send an email (supports --attachment and --attachment-ref)
   get-emails     List inbox emails
   get-email      Get a single email by message ID
-  delete-email   Soft-delete a received email by message ID
+  delete-email   Soft-delete a received email by message ID (alias: archive-email)
   get-last-email  Get the most recent email
   get-email-count  Get inbox email count
   get-sent-emails  List sent emails
@@ -2549,6 +2550,7 @@ Examples:
   inboxapi get-emails --limit 5
   inboxapi get-emails --limit 5 --human
   inboxapi delete-email \"<msg-id>\" --force
+  inboxapi archive-email \"<msg-id>\" --force
   inboxapi get-last-email
   inboxapi get-email-count
   inboxapi get-sent-emails --limit 10
@@ -8130,6 +8132,19 @@ mod tests {
     }
 
     #[test]
+    fn test_archive_email_alias_parses_positional_message_id() {
+        let cli = Cli::try_parse_from(["inboxapi", "archive-email", "<msg-id>", "--force"]).unwrap();
+
+        assert!(
+            matches!(
+                cli.command,
+                Some(Commands::DeleteEmail { message_id, force: true }) if message_id == "<msg-id>"
+            ),
+            "CLI arguments for archive-email alias should be parsed correctly"
+        );
+    }
+
+    #[test]
     fn test_delete_email_prompt_mode() {
         assert!(
             !delete_email_prompt_mode(true, false).expect("force should skip prompting"),
@@ -8829,6 +8844,10 @@ mod tests {
         assert!(
             CLI_HELP_TEXT.contains("delete-email"),
             "CLI help text should include the delete-email command"
+        );
+        assert!(
+            CLI_HELP_TEXT.contains("archive-email"),
+            "CLI help text should include the archive-email alias"
         );
         assert!(
             CLI_HELP_TEXT.contains("search-emails"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8133,7 +8133,8 @@ mod tests {
 
     #[test]
     fn test_archive_email_alias_parses_positional_message_id() {
-        let cli = Cli::try_parse_from(["inboxapi", "archive-email", "<msg-id>", "--force"]).unwrap();
+        let cli =
+            Cli::try_parse_from(["inboxapi", "archive-email", "<msg-id>", "--force"]).unwrap();
 
         assert!(
             matches!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2514,7 +2514,7 @@ Commands:
   send-email     Send an email (supports --attachment and --attachment-ref)
   get-emails     List inbox emails
   get-email      Get a single email by message ID
-  delete-email   Soft-delete a received email by message ID (alias: archive-email)
+  delete-email   Archive (soft-delete) a received email by message ID (alias: archive-email)
   get-last-email  Get the most recent email
   get-email-count  Get inbox email count
   get-sent-emails  List sent emails


### PR DESCRIPTION
## Summary
- add `archive-email` as alias for `delete-email` in CLI command routing
- update help/docs/README text to expose alias usage
- include CodeQL workflow required by repository rules

## Validation
- `cargo fmt --all -- --check` ✅
- `cargo test -q` ❌ blocked in local runner: `linker 'cc' not found`
